### PR TITLE
Add Linux CI

### DIFF
--- a/.github/images/centos.Dockerfile
+++ b/.github/images/centos.Dockerfile
@@ -1,0 +1,19 @@
+ARG image=centos:8
+FROM $image
+
+# Install dependencies
+RUN yum update -y
+RUN yum groupinstall -y 'Development Tools'
+RUN yum install -y autoconf automake findutils
+
+# Add source code
+ADD . /src
+WORKDIR /src
+
+# Run steps
+RUN ./bootstrap
+RUN ./configure
+RUN make
+RUN make check
+RUN make distcheck
+

--- a/.github/images/centos:7.Dockerfile
+++ b/.github/images/centos:7.Dockerfile
@@ -1,0 +1,1 @@
+centos.Dockerfile

--- a/.github/images/centos:8.Dockerfile
+++ b/.github/images/centos:8.Dockerfile
@@ -1,0 +1,1 @@
+centos.Dockerfile

--- a/.github/images/debian.Dockerfile
+++ b/.github/images/debian.Dockerfile
@@ -1,0 +1,22 @@
+ARG image=debian:buster
+FROM $image
+
+# From https://github.com/docker-library/postgres/blob/69bc540ecfffecce72d49fa7e4a46680350037f9/9.6/Dockerfile#L21-L24
+RUN apt-get update && apt-get install -y locales && rm -rf /var/lib/apt/lists/* \
+    && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+ENV LANG en_US.utf8
+
+# Install dependencies
+RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y build-essential autoconf automake markdown && rm -rf /var/lib/apt/lists/*
+
+# Add source code
+ADD . /src
+WORKDIR /src
+
+# Run steps
+RUN ./bootstrap
+RUN ./configure
+RUN make
+RUN make check
+RUN make distcheck
+

--- a/.github/images/debian:buster.Dockerfile
+++ b/.github/images/debian:buster.Dockerfile
@@ -1,0 +1,1 @@
+debian.Dockerfile

--- a/.github/images/debian:stretch.Dockerfile
+++ b/.github/images/debian:stretch.Dockerfile
@@ -1,0 +1,1 @@
+debian.Dockerfile

--- a/.github/images/fedora:30.Dockerfile
+++ b/.github/images/fedora:30.Dockerfile
@@ -1,0 +1,1 @@
+centos.Dockerfile

--- a/.github/images/fedora:31.Dockerfile
+++ b/.github/images/fedora:31.Dockerfile
@@ -1,0 +1,1 @@
+centos.Dockerfile

--- a/.github/images/ubuntu:bionic.Dockerfile
+++ b/.github/images/ubuntu:bionic.Dockerfile
@@ -1,0 +1,1 @@
+debian.Dockerfile

--- a/.github/images/ubuntu:xenial.Dockerfile
+++ b/.github/images/ubuntu:xenial.Dockerfile
@@ -1,0 +1,1 @@
+debian.Dockerfile

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,20 @@
+name: Build and test (single linux distro)
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: bootstrap
+      run: ./bootstrap
+    - name: configure
+      run: ./configure
+    - name: make
+      run: make
+    - name: make check
+      run: make check
+    - name: make distcheck
+      run: make distcheck
+

--- a/.github/workflows/matrixbuild.yml
+++ b/.github/workflows/matrixbuild.yml
@@ -1,0 +1,23 @@
+name: Build and test (linux matrix)
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        dockerenv:
+          - debian:buster
+          - debian:stretch
+          - ubuntu:bionic
+          - ubuntu:xenial
+          - centos:8
+          - centos:7
+          - fedora:31
+          - fedora:30
+    steps:
+    - uses: actions/checkout@v1
+    - name: Run build on ${{matrix.dockerenv}}
+      run: docker build . --file .github/images/${{matrix.dockerenv}}.Dockerfile --build-arg image=${{matrix.dockerenv}}


### PR DESCRIPTION
This PR uses Github's Actions feature to implement a basic CI that validates "does it build and test" for linux hosts.

There is a single-distro job that checks pull requests and a matrix job that only runs on pushes to the repo.