### PR TITLE
Remove superfluous semi-colon after closing brace

### DIFF
--- a/bgpq4.c
+++ b/bgpq4.c
@@ -72,7 +72,7 @@ usage(int ecode)
 	printf(" -X        : generate Cisco IOS XR output\n");
 	printf("\n" PACKAGE_NAME " version: " PACKAGE_VERSION "\n");
 	exit(ecode);
-};
+}
 
 void
 exclusive()
@@ -80,7 +80,7 @@ exclusive()
 	fprintf(stderr,"-E, -f <asnum>, -G <asnum>, and -t are mutually "
 	    "exclusive\n");
 	exit(1);
-};
+}
 
 void
 vendor_exclusive()
@@ -89,7 +89,7 @@ vendor_exclusive()
 	    " -j (JSON), -N (Nokia SR OS Classic), -n (Nokia SR OS MD-CLI),"
 	    " -U (Huawei) and -X (IOS XR) options are mutually exclusive\n");
 	exit(1);
-};
+}
 
 int
 parseasnumber(struct bgpq_expander* expander, char* optarg)
@@ -99,7 +99,7 @@ parseasnumber(struct bgpq_expander* expander, char* optarg)
 	if (expander->asnumber < 1 || expander->asnumber > (65535ul * 65535)) {
 		sx_report(SX_FATAL,"Invalid AS number: %s\n", optarg);
 		exit(1);
-	};
+	}
 	if(eon && *eon == '.') {
 		/* -f 3.3, for example */
 		uint32_t loas = strtoul(eon+1, &eon, 10);
@@ -107,24 +107,24 @@ parseasnumber(struct bgpq_expander* expander, char* optarg)
 			/* should prevent incorrect numbers like 65537.1 */
 			sx_report(SX_FATAL,"Invalid AS number: %s\n", optarg);
 			exit(1);
-		};
+		}
 		if(loas < 1 || loas > 65535) {
 			sx_report(SX_FATAL,"Invalid AS number: %s\n", optarg);
 			exit(1);
-		};
+		}
 		if (eon && *eon) {
 			sx_report(SX_FATAL,"Invalid symbol in AS number: "
 			    "%c (%s)\n", *eon, optarg);
 			exit(1);
-		};
+		}
 		expander->asnumber=(expander->asnumber << 16) + loas;
 	} else if (eon && *eon) {
 		sx_report(SX_FATAL,"Invalid symbol in AS number: %c (%s)\n",
 			*eon, optarg);
 		exit(1);
-	};
+	}
 	return 0;
-};
+}
 
 int
 main(int argc, char* argv[])
@@ -159,7 +159,7 @@ main(int argc, char* argv[])
 				sx_report(SX_FATAL, "-4 and -6 are mutually "
 				    "exclusive\n");
 				exit(1);
-			};
+			}
 			selectedipv4=1;
 			break;
 		case '6':
@@ -167,7 +167,7 @@ main(int argc, char* argv[])
 				sx_report(SX_FATAL, "-4 and -6 are mutually "
 				    "exclusive\n");
 				exit(1);
-			};
+			}
 			af = AF_INET6;
 			expander.family = AF_INET6;
 			expander.tree->family = AF_INET6;
@@ -224,8 +224,8 @@ main(int argc, char* argv[])
 				if (d) {
 					*d = 0;
 					expander.port = d + 1;
-				};
-			};
+				}
+			}
 			break;
 		case 'J':
 			if (expander.vendor)
@@ -251,7 +251,7 @@ main(int argc, char* argv[])
 				sx_report(SX_FATAL, "Invalid refineLow value:"
 				    " %s\n", optarg);
 				exit(1);
-			};
+			}
 			break;
 		case 'R':
 			refine = strtoul(optarg, NULL, 10);
@@ -259,7 +259,7 @@ main(int argc, char* argv[])
 				sx_report(SX_FATAL,"Invalid refine length:"
 				    " %s\n", optarg);
 				exit(1);
-			};
+			}
 			break;
 		case 'l':
 			expander.name = optarg;
@@ -270,7 +270,7 @@ main(int argc, char* argv[])
 				sx_report(SX_FATAL, "Invalid maximum recursion"
 				    " (-L): %s\n", optarg);
 				exit(1);
-			};
+			}
 			break;
 		case 'm':
 			maxlen=strtoul(optarg, NULL, 10);
@@ -278,7 +278,7 @@ main(int argc, char* argv[])
 				sx_report(SX_FATAL, "Invalid maxlen (-m): %s\n",
 				    optarg);
 				exit(1);
-			};
+			}
 			break;
 		case 'M':
 			{
@@ -310,17 +310,17 @@ main(int argc, char* argv[])
 						    isprint(*c) ? *c : 20,
 						    *c, optarg);
 						exit(1);
-					};
+					}
 				} else {
 					if (c != d) {
 						*d = *c;
-					};
+					}
 					d++;
 					c++;
-				};
-			};
+				}
+			}
 			*d = 0;
-			};
+			}
 			break;
 		case 'N':
 			if (expander.vendor)
@@ -357,7 +357,7 @@ main(int argc, char* argv[])
 				sx_report(SX_FATAL,"Invalid as-width: %s\n",
 				    optarg);
 				exit(1);
-			};
+			}
 			widthSet = 1;
 			break;
 		case 'w':
@@ -375,8 +375,8 @@ main(int argc, char* argv[])
 			break;
 		default:
 			usage(1);
-	};
-	};
+	}
+	}
 
 	argc -= optind;
 	argv += optind;
@@ -396,7 +396,7 @@ main(int argc, char* argv[])
 			} else if (expander.vendor == V_NOKIA ||
 			    expander.vendor == V_NOKIA_MD) {
 				expander.aswidth = 8;
-			};
+			}
 		} else if (expander.generation == T_OASPATH) {
 			if (expander.vendor == V_CISCO) {
 				expander.aswidth = 5;
@@ -407,29 +407,29 @@ main(int argc, char* argv[])
 			} else if (expander.vendor == V_NOKIA ||
 			    expander.vendor == V_NOKIA_MD) {
 				expander.aswidth = 8;
-			};
-		};
-	};
+			}
+		}
+	}
 
 	if (!expander.generation) {
 		expander.generation = T_PREFIXLIST;
-	};
+	}
 
 	if (expander.generation != (T_PREFIXLIST & T_ASPATH & T_OASPATH) &&
 	    expander.vendor == V_CISCO_XR) {
 		sx_report(SX_FATAL, "Sorry, only prefix-sets and as-paths "
 			"supported for IOS XR\n");
-	};
+	}
 	if (expander.vendor == V_BIRD && expander.generation != T_PREFIXLIST &&
 		expander.generation != T_ASPATH && expander.generation != T_ASSET) {
 		sx_report(SX_FATAL, "Sorry, only prefix-lists and as-paths/as-sets "
 		    "supported for BIRD output\n");
-	};
+	}
 	if (expander.vendor == V_JSON && expander.generation != T_PREFIXLIST &&
 		expander.generation != T_ASPATH && expander.generation != T_ASSET) {
 		sx_report(SX_FATAL, "Sorry, only prefix-lists and as-paths/as-sets "
 		    "supported for JSON output\n");
-	};
+	}
 
 	if (expander.vendor == V_FORMAT && expander.generation != T_PREFIXLIST)
 		sx_report(SX_FATAL, "Sorry, only prefix-lists supported in formatted "
@@ -439,7 +439,7 @@ main(int argc, char* argv[])
 		sx_report(SX_FATAL, "Sorry, formatted output (-F <fmt>) in not "
 		    "compatible with -R/-r options\n");
 		exit(1);
-	};
+	}
 
 	if (expander.vendor == V_HUAWEI && expander.generation != T_ASPATH &&
 	    expander.generation != T_OASPATH && expander.generation != T_PREFIXLIST)
@@ -463,64 +463,64 @@ main(int argc, char* argv[])
 		    " Juniper prefix-lists\nYou can try route-filters (-E) "
 		    "or route-filter-lists (-z) instead of prefix-lists\n.");
 		exit(1);
-	};
+	}
 
 	if(aggregate && expander.vendor == V_FORMAT) {
 		sx_report(SX_FATAL, "Sorry, aggregation (-A) is not compatible with "
 			"formatted output (-F <fmt>)\n");
 		exit(1);
-	};
+	}
 
 	if (aggregate && (expander.vendor == V_NOKIA_MD || expander.vendor == V_NOKIA)
 	    && expander.generation != T_PREFIXLIST) {
 		sx_report(SX_FATAL, "Sorry, aggregation (-A) is not supported with "
 		    "ip-prefix-lists (-E) on Nokia.\n");
 		exit(1);
-	};
+	}
 
 	if (refine && (expander.vendor == V_NOKIA_MD || expander.vendor == V_NOKIA)
 	    && expander.generation != T_PREFIXLIST) {
 		sx_report(SX_FATAL, "Sorry, more-specifics (-R) is not supported with "
 		    "ip-prefix-lists (-E) on Nokia.\n");
 		exit(1);
-	};
+	}
 
 	if (refineLow && (expander.vendor == V_NOKIA_MD || expander.vendor == V_NOKIA)
 	     && expander.generation != T_PREFIXLIST) {
 		sx_report(SX_FATAL, "Sorry, more-specifics (-r) is not supported with "
 		    "ip-prefix-lists (-E) on Nokia.\n");
 		exit(1);
-	};
+	}
 
 	if (aggregate && expander.generation < T_PREFIXLIST) {
 		sx_report(SX_FATAL, "Sorry, aggregation (-A) used only for prefix-"
 		    "lists, extended access-lists and route-filters\n");
 		exit(1);
-	};
+	}
 
 	if (expander.sequence && expander.vendor != V_CISCO) {
 		sx_report(SX_FATAL, "Sorry, prefix-lists sequencing (-s) supported"
 		    " only for IOS\n");
 		exit(1);
-	};
+	}
 
 	if (expander.sequence && expander.generation < T_PREFIXLIST) {
 		sx_report(SX_FATAL, "Sorry, prefix-lists sequencing (-s) can't be "
 		    " used for non prefix-list\n");
 		exit(1);
-	};
+	}
 
 	if (refineLow && !refine) {
 		if (expander.family == AF_INET)
 			refine = 32;
 		else
 			refine = 128;
-	};
+	}
 
 	if (refineLow && refineLow > refine) {
 		sx_report(SX_FATAL, "Incompatible values for -r %u and -R %u\n",
 		    refineLow, refine);
-	};
+	}
 
 	if (refine || refineLow) {
 		if (expander.family == AF_INET6 && refine > 128) {
@@ -535,7 +535,7 @@ main(int argc, char* argv[])
 		} else if (expander.family == AF_INET && refineLow > 32) {
 			sx_report(SX_FATAL, "Invalid value for refineLow(-r): %u (1-32 for"
 			    " IPv4)\n", refineLow);
-		};
+		}
 
 		if (expander.vendor == V_JUNIPER && expander.generation == T_PREFIXLIST) {
 			if (refine) {
@@ -548,8 +548,8 @@ main(int argc, char* argv[])
 				    "is not supported for Juniper prefix-lists.\n"
 				    "Use route-filters (-E) or route-filter-lists (-z) "
 				    "instead\n", refineLow);
-			};
-		};
+			}
+		}
 
 		if (expander.generation < T_PREFIXLIST) {
 			if (refine) {
@@ -558,9 +558,9 @@ main(int argc, char* argv[])
 			} else {
 				sx_report(SX_FATAL, "Sorry, more-specific filter (-r %u) "
 				    "supported only with prefix-list generation\n", refineLow);
-			};
-		};
-	};
+			}
+		}
+	}
 
 	if (maxlen) {
 		if ((expander.family == AF_INET6 && maxlen > 128)
@@ -575,36 +575,36 @@ main(int argc, char* argv[])
 			 * routes will be accepted, so save some CPU cycles :)
 			 */
 			expander.maxlen = maxlen;
-		};
+		}
 	} else if (expander.family == AF_INET) {
 		expander.maxlen = 32;
 	} else if (expander.family == AF_INET6) {
 		expander.maxlen = 128;
-	};
+	}
 
 	if (expander.generation == T_EACL && expander.vendor == V_CISCO
 	    && expander.family == AF_INET6) {
 		sx_report(SX_FATAL,"Sorry, ipv6 access-lists not supported "
 		    "for Cisco yet.\n");
-	};
+	}
 
 	if (expander.match != NULL
 	    && (expander.vendor != V_JUNIPER || expander.generation != T_EACL)) {
 		sx_report(SX_FATAL, "Sorry, extra match conditions (-M) can be used "
 		    "only with Juniper route-filters\n");
-	};
+	}
 
 	if ((expander.generation == T_ASPATH || expander.generation == T_OASPATH)
 	    && af != AF_INET && !expander.validate_asns) {
 		sx_report(SX_FATAL, "Sorry, -6 makes no sense with as-path (-f/-G) "
 		    "generation\n");
-	};
+	}
 
 	if (expander.validate_asns && expander.generation != T_ASPATH
 	    && expander.generation != T_OASPATH) {
 		sx_report(SX_FATAL, "Sorry, -w makes sense only for as-path "
 		    "(-f/-G) generation\n");
-	};
+	}
 
 	if (!argv[0])
 		usage(1);
@@ -628,10 +628,10 @@ main(int argc, char* argv[])
 				} else {
 					SX_DEBUG(debug_expander,"Unknown sub-as"
 					    " object %s\n", argv[0]);
-				};
+				}
 			} else {
 				bgpq_expander_add_as(&expander,argv[0]);
-			};
+			}
 		} else {
 			char* c = strchr(argv[0], '^');
 			if (!c && !bgpq_expander_add_prefix(&expander, argv[0])) {
@@ -643,11 +643,11 @@ main(int argc, char* argv[])
 				    "%s (bad range or address-family)\n",
 				    argv[0]);
 				exit(1);
-			};
-		};
+			}
+		}
 		argv++;
 		argc--;
-	};
+	}
 
 	if (!bgpq_expand(&expander))
 		exit(1);
@@ -683,9 +683,9 @@ main(int argc, char* argv[])
 		case T_ROUTE_FILTER_LIST:
 			bgpq4_print_route_filter_list(stdout, &expander);
 			break;
-	};
+	}
 
         expander_freeall(&expander);
 
 	return 0;
-};
+}

--- a/bgpq4_printer.c
+++ b/bgpq4_printer.c
@@ -36,7 +36,7 @@ bgpq4_print_cisco_aspath(FILE* f, struct bgpq_expander* b)
 			    "^%u(_%u)*$\n", b->name ? b->name : "NN",
 			    b->asnumber, b->asnumber);
 			empty = 0;
-	};
+	}
 
 	for (k = 0; k < 65536; k++) {
 		if (!b->asn32s[k])
@@ -54,11 +54,11 @@ bgpq4_print_cisco_aspath(FILE* f, struct bgpq_expander* b)
 						    b->asnumber,
 						    k * 65536 + i * 8 + j);
 						empty = 0;
-					};
+					}
 				} else {
 					fprintf(f, "|%u", k * 65536 + i * 8 + j);
 					empty = 0;
-				};
+				}
 			}
 
 			nc++;
@@ -66,9 +66,9 @@ bgpq4_print_cisco_aspath(FILE* f, struct bgpq_expander* b)
 			if (nc == b->aswidth) {
 				fprintf(f, ")$\n");
 				nc = 0;
-			};
-		};
-	};
+			}
+		}
+	}
 
 	if (nc)
 		fprintf(f, ")$\n");
@@ -78,7 +78,7 @@ bgpq4_print_cisco_aspath(FILE* f, struct bgpq_expander* b)
 		    b->name ? b->name : "NN");
 
 	return 0;
-};
+}
 
 int
 bgpq4_print_cisco_xr_aspath(FILE* f, struct bgpq_expander* b)
@@ -93,7 +93,7 @@ bgpq4_print_cisco_xr_aspath(FILE* f, struct bgpq_expander* b)
 		fprintf(f,"\n  ios-regex '^%u(_%u)*$'", b->asnumber,
 		    b->asnumber);
 		comma = 1;
-	};
+	}
 
 	for (k = 0; k < 65536; k++) {
 
@@ -123,18 +123,18 @@ bgpq4_print_cisco_xr_aspath(FILE* f, struct bgpq_expander* b)
 					if (nc == b->aswidth) {
 						fprintf(f, ")$'");
 						nc = 0;
-					};
-				};
-			};
-		};
-	};
+					}
+				}
+			}
+		}
+	}
 
 	if (nc)
 		fprintf(f, ")$'");
 
 	fprintf(f, "\nend-set\n");
 	return 0;
-};
+}
 
 int
 bgpq4_print_cisco_oaspath(FILE* f, struct bgpq_expander* b)
@@ -149,7 +149,7 @@ bgpq4_print_cisco_oaspath(FILE* f, struct bgpq_expander* b)
 		fprintf(f,"ip as-path access-list %s permit ^(_%u)*$\n",
 		    b->name ? b->name : "NN",
 		    b->asnumber);
-	};
+	}
 
 	empty = 0;
 
@@ -172,11 +172,11 @@ bgpq4_print_cisco_oaspath(FILE* f, struct bgpq_expander* b)
 						    b->name ? b->name : "NN",
 						    k * 65536 + i * 8 + j);
 						empty = 0;
-					};
+					}
 				} else {
 					fprintf(f,"|%u",k*65536+i*8+j);
 					empty=0;
-				};
+				}
 			}
 
 			nc++;
@@ -184,9 +184,9 @@ bgpq4_print_cisco_oaspath(FILE* f, struct bgpq_expander* b)
 			if (nc==b->aswidth) {
 				fprintf(f,")$\n");
 				nc=0;
-			};
-		};
-	};
+			}
+		}
+	}
 
 	if (nc)
 		fprintf(f,")$\n");
@@ -196,7 +196,7 @@ bgpq4_print_cisco_oaspath(FILE* f, struct bgpq_expander* b)
 		    b->name ? b->name : "NN");
 
 	return 0;
-};
+}
 
 int
 bgpq4_print_cisco_xr_oaspath(FILE* f, struct bgpq_expander* b)
@@ -210,7 +210,7 @@ bgpq4_print_cisco_xr_oaspath(FILE* f, struct bgpq_expander* b)
 	    (0x80 >> (b->asnumber % 8))) {
 		fprintf(f,"\n  ios-regex '^(_%u)*$'", b->asnumber);
 		comma = 1;
-	};
+	}
 
 	for (k = 0; k < 65536; k++) {
 
@@ -238,11 +238,11 @@ bgpq4_print_cisco_xr_oaspath(FILE* f, struct bgpq_expander* b)
 					if (nc == b->aswidth) {
 						fprintf(f,")$'");
 						nc=0;
-					};
-				};
-			};
-		};
-	};
+					}
+				}
+			}
+		}
+	}
 
 	if (nc)
 		fprintf(f,")$'");
@@ -250,7 +250,7 @@ bgpq4_print_cisco_xr_oaspath(FILE* f, struct bgpq_expander* b)
 	fprintf(f,"\nend-set\n");
 
 	return 0;
-};
+}
 
 int
 bgpq4_print_juniper_aspath(FILE* f, struct bgpq_expander* b)
@@ -266,7 +266,7 @@ bgpq4_print_juniper_aspath(FILE* f, struct bgpq_expander* b)
 		fprintf(f,"  as-path a%u \"^%u(%u)*$\";\n", lineNo,
 		    b->asnumber, b->asnumber);
 		lineNo++;
-	};
+	}
 
 	for (k = 0; k < 65536; k++) {
 
@@ -287,7 +287,7 @@ bgpq4_print_juniper_aspath(FILE* f, struct bgpq_expander* b)
 					} else {
 						fprintf(f,"|%u",
 						    k * 65536 + i * 8 + j);
-					};
+					}
 
 					nc++;
 
@@ -295,11 +295,11 @@ bgpq4_print_juniper_aspath(FILE* f, struct bgpq_expander* b)
 						fprintf(f, ")$\";\n");
 						nc = 0;
 						lineNo++;
-					};
-				};
-			};
-		};
-	};
+					}
+				}
+			}
+		}
+	}
 
 	if (nc)
 		fprintf(f, ")$\";\n");
@@ -309,7 +309,7 @@ bgpq4_print_juniper_aspath(FILE* f, struct bgpq_expander* b)
 	fprintf(f, " }\n}\n");
 
 	return 0;
-};
+}
 
 int
 bgpq4_print_juniper_oaspath(FILE* f, struct bgpq_expander* b)
@@ -325,7 +325,7 @@ bgpq4_print_juniper_oaspath(FILE* f, struct bgpq_expander* b)
 		fprintf(f, "  as-path a%u \"^%u(%u)*$\";\n", lineNo,
 		    b->asnumber, b->asnumber);
 		lineNo++;
-	};
+	}
 
 	for (k = 0; k < 65536; k++) {
 
@@ -354,11 +354,11 @@ bgpq4_print_juniper_oaspath(FILE* f, struct bgpq_expander* b)
 						fprintf(f, ")$\";\n");
 						nc = 0;
 						lineNo++;
-					};
-				};
-			};
-		};
-	};
+					}
+				}
+			}
+		}
+	}
 
 	if (nc)
 		fprintf(f, ")$\";\n");
@@ -368,7 +368,7 @@ bgpq4_print_juniper_oaspath(FILE* f, struct bgpq_expander* b)
 	fprintf(f, " }\n}\n");
 
 	return 0;
-};
+}
 
 int
 bgpq4_print_openbgpd_oaspath(FILE* f, struct bgpq_expander* b)
@@ -387,16 +387,16 @@ bgpq4_print_openbgpd_oaspath(FILE* f, struct bgpq_expander* b)
 					    b->asnumber,
 					    k * 65536 + i * 8 + j);
 					lineNo++;
-				};
-			};
-		};
-	};
+				}
+			}
+		}
+	}
 
 	if (!lineNo)
 		fprintf(f, "deny to AS %u\n", b->asnumber);
 
 	return 0;
-};
+}
 
 int
 bgpq4_print_nokia_aspath(FILE* f, struct bgpq_expander* b)
@@ -415,7 +415,7 @@ bgpq4_print_nokia_aspath(FILE* f, struct bgpq_expander* b)
 		fprintf(f, "  entry %u expression \"%u+\"\n", lineNo,
 		    b->asnumber);
 		lineNo++;
-	};
+	}
 
 	for (k = 0; k < 65536; k++) {
 
@@ -436,7 +436,7 @@ bgpq4_print_nokia_aspath(FILE* f, struct bgpq_expander* b)
 					} else {
 						fprintf(f, " %u",
 						    k * 65536 + i * 8 + j);
-					};
+					}
 
 					nc++;
 
@@ -444,11 +444,11 @@ bgpq4_print_nokia_aspath(FILE* f, struct bgpq_expander* b)
 						fprintf(f, "]\"\n");
 						nc = 0;
 						lineNo++;
-					};
-				};
-			};
-		};
-	};
+					}
+				}
+			}
+		}
+	}
 
 	if (nc)
 		fprintf(f, "]\"\n");
@@ -456,7 +456,7 @@ bgpq4_print_nokia_aspath(FILE* f, struct bgpq_expander* b)
 	fprintf(f,"exit\ncommit\n");
 
 	return 0;
-};
+}
 
 int
 bgpq4_print_nokia_md_aspath(FILE* f, struct bgpq_expander* b)
@@ -473,7 +473,7 @@ bgpq4_print_nokia_md_aspath(FILE* f, struct bgpq_expander* b)
 		fprintf(f,"  entry %u {\n    expression \"%u+\"\n  }\n",
 		    lineNo, b->asnumber);
 		lineNo++;
-	};
+	}
 
 	for (k = 0; k < 65536; k++) {
 
@@ -495,7 +495,7 @@ bgpq4_print_nokia_md_aspath(FILE* f, struct bgpq_expander* b)
 					} else {
 						fprintf(f, " %u",
 						    k * 65536 + i * 8 + j);
-					};
+					}
 
 					nc++;
 
@@ -503,11 +503,11 @@ bgpq4_print_nokia_md_aspath(FILE* f, struct bgpq_expander* b)
 						fprintf(f,"]\"\n  }\n");
 						nc = 0;
 						lineNo++;
-					};
-				};
-			};
-		};
-	};
+					}
+				}
+			}
+		}
+	}
 
 	if (nc)
 		fprintf(f,"]\"\n  }\n");
@@ -515,7 +515,7 @@ bgpq4_print_nokia_md_aspath(FILE* f, struct bgpq_expander* b)
 	fprintf(f, "}\n");
 
 	return 0;
-};
+}
 
 
 int
@@ -532,7 +532,7 @@ bgpq4_print_huawei_aspath(FILE* f, struct bgpq_expander* b)
 		fprintf(f, "ip as-path-filter %s permit ^%u(%u)*$\n",
 		    b->name ? b->name : "NN", b->asnumber, b->asnumber);
 		empty=0;
-	};
+	}
 
 	for (k=0; k<65536; k++) {
 
@@ -557,18 +557,18 @@ bgpq4_print_huawei_aspath(FILE* f, struct bgpq_expander* b)
 					} else {
 						fprintf(f, "|%u",
 						    k * 65536 + i * 8 + j);
-					};
+					}
 
 					nc++;
 
 					if (nc == b->aswidth) {
 						fprintf(f, ")$\n");
 						nc = 0;
-					};
-				};
-			};
-		};
-	};
+					}
+				}
+			}
+		}
+	}
 
 	if (nc)
 		fprintf(f, ")$\n");
@@ -578,7 +578,7 @@ bgpq4_print_huawei_aspath(FILE* f, struct bgpq_expander* b)
 		    b->name ? b->name : "NN");
 
 	return 0;
-};
+}
 
 int
 bgpq4_print_huawei_oaspath(FILE* f, struct bgpq_expander* b)
@@ -594,7 +594,7 @@ bgpq4_print_huawei_oaspath(FILE* f, struct bgpq_expander* b)
 		fprintf(f,"ip as-path-filter %s permit (_%u)*$\n",
 		    b->name ? b->name : "NN", b->asnumber);
 		empty = 0;
-	};
+	}
 
 	for ( k = 0 ; k < 65536 ; k++) {
 
@@ -622,11 +622,11 @@ bgpq4_print_huawei_oaspath(FILE* f, struct bgpq_expander* b)
 					if (nc == b->aswidth) {
 						fprintf(f, ")$\n");
 						nc = 0;
-					};
-				};
-			};
-		};
-	};
+					}
+				}
+			}
+		}
+	}
 
 	if (nc)
 		fprintf(f, ")$\n");
@@ -636,7 +636,7 @@ bgpq4_print_huawei_oaspath(FILE* f, struct bgpq_expander* b)
 		    b->name ? b->name : "NN");
 
 	return 0;
-};
+}
 
 int
 bgpq4_print_nokia_oaspath(FILE* f, struct bgpq_expander* b)
@@ -653,7 +653,7 @@ bgpq4_print_nokia_oaspath(FILE* f, struct bgpq_expander* b)
 		fprintf(f, "  entry %u expression \"%u+\"\n", lineNo,
 		    b->asnumber);
 		lineNo++;
-	};
+	}
 
 	for (k = 0; k < 65536; k++) {
 
@@ -681,17 +681,17 @@ bgpq4_print_nokia_oaspath(FILE* f, struct bgpq_expander* b)
 						fprintf(f,"]\"\n");
 						nc = 0;
 						lineNo++;
-					};
-				};
-			};
-		};
-	};
+					}
+				}
+			}
+		}
+	}
 
 	if (nc)
 		fprintf(f, "]\"\n");
 
 	return 0;
-};
+}
 
 int
 bgpq4_print_nokia_md_oaspath(FILE* f, struct bgpq_expander* b)
@@ -708,7 +708,7 @@ bgpq4_print_nokia_md_oaspath(FILE* f, struct bgpq_expander* b)
 		fprintf(f, "  entry %u {\n    expression \"%u+\"\n  }\n",
 		    lineNo, b->asnumber);
 		lineNo++;
-	};
+	}
 
 	for (k = 0; k < 65536; k++) {
 
@@ -737,11 +737,11 @@ bgpq4_print_nokia_md_oaspath(FILE* f, struct bgpq_expander* b)
 						fprintf(f, "]\"\n  }\n");
 						nc = 0;
 						lineNo++;
-					};
-				};
-			};
-		};
-	};
+					}
+				}
+			}
+		}
+	}
 
 	if (nc)
 		fprintf(f,"]\"\n  }\n");
@@ -749,7 +749,7 @@ bgpq4_print_nokia_md_oaspath(FILE* f, struct bgpq_expander* b)
 	fprintf(f, "}\n");
 
 	return 0;
-};
+}
 
 int
 bgpq4_print_aspath(FILE* f, struct bgpq_expander* b)
@@ -774,10 +774,10 @@ bgpq4_print_aspath(FILE* f, struct bgpq_expander* b)
 		return bgpq4_print_huawei_aspath(f, b);
 	} else {
 		sx_report(SX_FATAL,"Unknown vendor %i\n", b->vendor);
-	};
+	}
 
 	return 0;
-};
+}
 
 int
 bgpq4_print_oaspath(FILE* f, struct bgpq_expander* b)
@@ -798,10 +798,10 @@ bgpq4_print_oaspath(FILE* f, struct bgpq_expander* b)
 		return bgpq4_print_huawei_oaspath(f, b);
 	} else {
 		sx_report(SX_FATAL,"Unknown vendor %i\n", b->vendor);
-	};
+	}
 
 	return 0;
-};
+}
 
 int
 bgpq4_print_asset(FILE* f, struct bgpq_expander* b)
@@ -817,8 +817,8 @@ bgpq4_print_asset(FILE* f, struct bgpq_expander* b)
 		sx_report(SX_FATAL, "as-sets (-t) supported for JSON, "
 		    "OpenBGPD, and BIRD only\n");
 		return -1;
-	};
-};
+	}
+}
 
 void
 bgpq4_print_jprefix(struct sx_radix_node* n, void* ff)
@@ -834,7 +834,7 @@ bgpq4_print_jprefix(struct sx_radix_node* n, void* ff)
 
 	sx_prefix_snprintf(n->prefix, prefix, sizeof(prefix));
 	fprintf(f,"    %s;\n", prefix);
-};
+}
 
 static int   needscomma=0;
 
@@ -864,14 +864,14 @@ bgpq4_print_json_prefix(struct sx_radix_node* n, void* ff)
 		fprintf(f, "%s\n    { \"prefix\": \"%s\", \"exact\": false, "
 		    "\"less-equal\": %u }", needscomma ? "," : "", prefix,
 		    n->aggregateHi);
-	};
+	}
 
 	needscomma = 1;
 
 checkSon:
 	if (n->son)
 		bgpq4_print_json_prefix(n->son, ff);
-};
+}
 
 int
 bgpq4_print_json_aspath(FILE* f, struct bgpq_expander* b)
@@ -906,15 +906,15 @@ bgpq4_print_json_aspath(FILE* f, struct bgpq_expander* b)
 
 					if (nc == b->aswidth)
 						nc = 0;
-				};
-			};
-		};
-	};
+				}
+			}
+		}
+	}
 
 	fprintf(f,"\n]}\n");
 
 	return 0;
-};
+}
 
 void
 bgpq4_print_bird_prefix(struct sx_radix_node* n, void* ff)
@@ -938,14 +938,14 @@ bgpq4_print_bird_prefix(struct sx_radix_node* n, void* ff)
 	} else {
 		fprintf(f, "%s\n    %s{%u,%u}", needscomma ? "," : "", prefix,
 		    n->prefix->masklen, n->aggregateHi);
-	};
+	}
 
 	needscomma = 1;
 
 checkSon:
 	if (n->son)
 		bgpq4_print_bird_prefix(n->son, ff);
-};
+}
 
 int
 bgpq4_print_bird_aspath(FILE* f, struct bgpq_expander* b)
@@ -977,22 +977,22 @@ bgpq4_print_bird_aspath(FILE* f, struct bgpq_expander* b)
 					} else {
 						fprintf(f, ", %u",
 						    k * 65536 + i * 8 + j);
-					};
+					}
 
 					nc++;
 
 					if (nc == b->aswidth)
 						nc = 0;
-				};
-			};
-		};
-	};
+				}
+			}
+		}
+	}
 
 	if (!empty)
 		fprintf(f, "];\n");
 
 	return 0;
-};
+}
 
 void
 bgpq4_print_openbgpd_prefix(struct sx_radix_node* n, void* ff)
@@ -1018,12 +1018,12 @@ bgpq4_print_openbgpd_prefix(struct sx_radix_node* n, void* ff)
 	} else {
 		fprintf(f, "\n\t%s prefixlen %u - %u",
 		    prefix, n->prefix->masklen, n->aggregateHi);
-	};
+	}
 
 checkSon:
 	if (n->son)
 		bgpq4_print_openbgpd_prefix(n->son, ff);
-};
+}
 
 int
 bgpq4_print_openbgpd_asset(FILE* f, struct bgpq_expander* b)
@@ -1048,15 +1048,15 @@ bgpq4_print_openbgpd_asset(FILE* f, struct bgpq_expander* b)
 
 					if (nc == b->aswidth)
 						nc = 0;
-				};
-			};
-		};
-	};
+				}
+			}
+		}
+	}
 
 	fprintf(f, "\n}\n");
 
 	return 0;
-};
+}
 
 int
 bgpq4_print_openbgpd_aspath(FILE* f, struct bgpq_expander* b)
@@ -1074,16 +1074,16 @@ bgpq4_print_openbgpd_aspath(FILE* f, struct bgpq_expander* b)
 					fprintf(f, "allow from AS %u AS %u\n",
 					    b->asnumber, k * 65536 + i * 8 + j);
 					lineNo++;
-				};
-			};
-		};
-	};
+				}
+			}
+		}
+	}
 
 	if (!lineNo)
 		fprintf(f, "deny from AS %u\n", b->asnumber);
 
 	return 0;
-};
+}
 
 static int jrfilter_prefixed = 1;
 
@@ -1113,13 +1113,13 @@ bgpq4_print_jrfilter(struct sx_radix_node* n, void* ff)
 			fprintf(f,"    %s%s upto /%u;\n",
 			    jrfilter_prefixed ? "route-filter " : "",
 			    prefix, n->aggregateHi);
-		};
-	};
+		}
+	}
 
 checkSon:
 	if (n->son)
 		bgpq4_print_jrfilter(n->son, ff);
-};
+}
 
 static char* bname = NULL;
 static int   seq = 0;
@@ -1152,17 +1152,17 @@ bgpq4_print_cprefix(struct sx_radix_node* n, void* ff)
 			    n->prefix->family == AF_INET ? "ip" : "ipv6",
 			    bname?bname:"NN", seqno, prefix,
 			    n->aggregateHi);
-		};
+		}
 	} else {
 		fprintf(f,"%s prefix-list %s%s permit %s\n",
 		    n->prefix->family==AF_INET ? "ip" : "ipv6",
 		    bname ? bname : "NN", seqno, prefix);
-	};
+	}
 
 checkSon:
 	if (n->son)
 		bgpq4_print_cprefix(n->son,ff);
-};
+}
 
 void
 bgpq4_print_cprefixxr(struct sx_radix_node* n, void* ff)
@@ -1187,19 +1187,19 @@ bgpq4_print_cprefixxr(struct sx_radix_node* n, void* ff)
 			fprintf(f,"%s%s le %u",
 			    needscomma ? ",\n " : " ",
 			    prefix, n->aggregateHi);
-		};
+		}
 	} else {
 		fprintf(f, "%s%s",
 		    needscomma ? ",\n " : " ",
 		    prefix);
-	};
+	}
 
 	needscomma = 1;
 
 checkSon:
 	if (n->son)
 		bgpq4_print_cprefixxr(n->son, ff);
-};
+}
 
 void
 bgpq4_print_hprefix(struct sx_radix_node* n, void* ff)
@@ -1227,18 +1227,18 @@ bgpq4_print_hprefix(struct sx_radix_node* n, void* ff)
 			    n->prefix->family == AF_INET ? "ip" : "ipv6",
 			    bname ? bname : "NN",
 			    prefix, n->aggregateHi);
-		};
+		}
 	} else {
 		fprintf(f,"ip %s-prefix %s permit %s\n",
 		    n->prefix->family == AF_INET ? "ip" : "ipv6",
 		    bname ? bname : "NN",
 		    prefix);
-	};
+	}
 
 checkSon:
 	if (n->son)
 		bgpq4_print_hprefix(n->son, ff);
-};
+}
 
 
 void
@@ -1267,7 +1267,7 @@ bgpq4_print_ceacl(struct sx_radix_node* n, void* ff)
 	} else {
 	 	netmask <<= (32 - n->prefix->masklen);
 		netmask &= 0xfffffffful;
-	};
+	}
 	netmask = htonl(netmask);
 
 	if (n->isAggregate) {
@@ -1279,7 +1279,7 @@ bgpq4_print_ceacl(struct sx_radix_node* n, void* ff)
 			wild2addr = 0;
 		} else {
 			wild2addr = 0xfffffffful >> n->aggregateHi;
-		};
+		}
 		wildaddr = wildaddr &(~wild2addr);
 
 		if (masklen == 32)
@@ -1307,7 +1307,7 @@ bgpq4_print_ceacl(struct sx_radix_node* n, void* ff)
 		} else {
 			fprintf(f, " permit ip host %s ",
 			    inet_ntoa(n->prefix->addr.addr));
-		};
+		}
 
 		if (wildmask) {
 			fprintf(f, "%s ",
@@ -1317,16 +1317,16 @@ bgpq4_print_ceacl(struct sx_radix_node* n, void* ff)
 		} else {
 			fprintf(f, "host %s\n",
 			    inet_ntoa(*(struct in_addr*) & mask));
-		};
+		}
 	} else {
 		fprintf(f, " permit ip host %s host %s\n", prefix,
 		    inet_ntoa(*(struct in_addr*) & netmask));
-	};
+	}
 
 checkSon:
 	if (n->son)
 		bgpq4_print_ceacl(n->son, ff);
-};
+}
 
 void
 bgpq4_print_nokia_ipfilter(struct sx_radix_node* n, void* ff)
@@ -1347,7 +1347,7 @@ bgpq4_print_nokia_ipfilter(struct sx_radix_node* n, void* ff)
 checkSon:
 	if (n->son)
 		bgpq4_print_nokia_ipfilter(n->son, ff);
-};
+}
 
 void
 bgpq4_print_nokia_md_ipfilter(struct sx_radix_node* n, void* ff)
@@ -1368,7 +1368,7 @@ bgpq4_print_nokia_md_ipfilter(struct sx_radix_node* n, void* ff)
 checkSon:
 	if (n->son)
 		bgpq4_print_nokia_md_ipfilter(n->son, ff);
-};
+}
 
 void
 bgpq4_print_nokia_prefix(struct sx_radix_node* n, void* ff)
@@ -1393,14 +1393,14 @@ bgpq4_print_nokia_prefix(struct sx_radix_node* n, void* ff)
 		} else {
 			fprintf(f,"    prefix %s prefix-length-range %u-%u\n",
 			    prefix, n->prefix->masklen, n->aggregateHi);
-		};
-	};
+		}
+	}
 
 checkSon:
 	if (n->son)
 		bgpq4_print_nokia_prefix(n->son, ff);
 
-};
+}
 
 void
 bgpq4_print_nokia_md_prefix(struct sx_radix_node* n, void* ff)
@@ -1428,14 +1428,14 @@ bgpq4_print_nokia_md_prefix(struct sx_radix_node* n, void* ff)
 			fprintf(f,"    prefix %s type through {\n        "
 			    "through-length %u\n    }\n", prefix,
 			    n->aggregateHi);
-		};
-	};
+		}
+	}
 
 checkSon:
 	if (n->son)
 		bgpq4_print_nokia_md_prefix(n->son, ff);
 
-};
+}
 
 int
 bgpq4_print_juniper_prefixlist(FILE* f, struct bgpq_expander* b)
@@ -1448,7 +1448,7 @@ bgpq4_print_juniper_prefixlist(FILE* f, struct bgpq_expander* b)
 	fprintf(f, " }\n}\n");
 
 	return 0;
-};
+}
 
 int
 bgpq4_print_juniper_routefilter(FILE* f, struct bgpq_expander* b)
@@ -1468,7 +1468,7 @@ bgpq4_print_juniper_routefilter(FILE* f, struct bgpq_expander* b)
 		    "replace:\n  from {\n", b->name ? b->name : "NN");
 		if (b->match)
 			fprintf(f, "    %s;\n", b->match);
-	};
+	}
 
 	if (!sx_radix_tree_empty(b->tree)) {
 		jrfilter_prefixed = 1;
@@ -1476,16 +1476,16 @@ bgpq4_print_juniper_routefilter(FILE* f, struct bgpq_expander* b)
 	} else {
 		fprintf(f, "    route-filter %s/0 orlonger reject;\n",
 			b->tree->family == AF_INET ? "0.0.0.0" : "::");
-	};
+	}
 
 	if (c) {
 		fprintf(f, "   }\n  }\n }\n}\n");
 	} else {
 		fprintf(f, "  }\n }\n}\n");
-	};
+	}
 
 	return 0;
-};
+}
 
 int
 bgpq4_print_openbgpd_prefixlist(FILE* f, struct bgpq_expander* b)
@@ -1498,7 +1498,7 @@ bgpq4_print_openbgpd_prefixlist(FILE* f, struct bgpq_expander* b)
 		if (!b->asnumber)
 			fprintf(f, "# use -a <asn> to generate \"deny from "
 			    "ASN <asn>\" instead of this list\n");
-	};
+	}
 
 	if (!sx_radix_tree_empty(b->tree) || !b->asnumber) {
 		if (b->name) {
@@ -1517,10 +1517,10 @@ bgpq4_print_openbgpd_prefixlist(FILE* f, struct bgpq_expander* b)
 		fprintf(f, "\n");
 	} else {
 		fprintf(f, "deny from AS %u\n", b->asnumber);
-	};
+	}
 
 	return 0;
-};
+}
 
 int
 bgpq4_print_openbgpd_prefixset(FILE* f, struct bgpq_expander* b)
@@ -1535,7 +1535,7 @@ bgpq4_print_openbgpd_prefixset(FILE* f, struct bgpq_expander* b)
 	fprintf(f, "\n}\n");
 
 	return 0;
-};
+}
 
 int
 bgpq4_print_cisco_prefixlist(FILE* f, struct bgpq_expander* b)
@@ -1555,10 +1555,10 @@ bgpq4_print_cisco_prefixlist(FILE* f, struct bgpq_expander* b)
 		    b->family==AF_INET ? "ip" : "ipv6",
 		    bname,
 		    b->family==AF_INET ? "0.0.0.0/0" : "::/0");
-	};
+	}
 
 	return 0;
-};
+}
 
 int
 bgpq4_print_ciscoxr_prefixlist(FILE* f, struct bgpq_expander* b)
@@ -1572,7 +1572,7 @@ bgpq4_print_ciscoxr_prefixlist(FILE* f, struct bgpq_expander* b)
 	fprintf(f, "\nend-set\n");
 
 	return 0;
-};
+}
 
 int
 bgpq4_print_json_prefixlist(FILE* f, struct bgpq_expander* b)
@@ -1585,7 +1585,7 @@ bgpq4_print_json_prefixlist(FILE* f, struct bgpq_expander* b)
 	fprintf(f,"\n] }\n");
 
 	return 0;
-};
+}
 
 int
 bgpq4_print_bird_prefixlist(FILE* f, struct bgpq_expander* b)
@@ -1597,10 +1597,10 @@ bgpq4_print_bird_prefixlist(FILE* f, struct bgpq_expander* b)
 		fprintf(f, "\n];\n");
 	} else {
 		SX_DEBUG(debug_expander, "skip empty prefix-list in BIRD format\n");
-	};
+	}
 
 	return 0;
-};
+}
 
 int
 bgpq4_print_huawei_prefixlist(FILE* f, struct bgpq_expander* b)
@@ -1618,10 +1618,10 @@ bgpq4_print_huawei_prefixlist(FILE* f, struct bgpq_expander* b)
 		    b->family==AF_INET ? "ip" : "ipv6",
 		    bname,
 		    b->family==AF_INET ? "0.0.0.0/0" : "::/0");
-	};
+	}
 
 	return 0;
-};
+}
 
 
 struct fpcbdata {
@@ -1650,7 +1650,7 @@ bgpq4_print_format_prefix(struct sx_radix_node* n, void* ff)
 	    b->format);
 
 	fprintf(f, "%s", prefix);
-};
+}
 
 
 int
@@ -1664,7 +1664,7 @@ bgpq4_print_format_prefixlist(FILE* f, struct bgpq_expander* b)
 		fprintf(f, "\n");
 
 	return 0;
-};
+}
 
 int
 bgpq4_print_nokia_prefixlist(FILE* f, struct bgpq_expander* b)
@@ -1676,7 +1676,7 @@ bgpq4_print_nokia_prefixlist(FILE* f, struct bgpq_expander* b)
 	sx_radix_tree_foreach(b->tree,bgpq4_print_nokia_prefix,f);
 	fprintf(f,"exit\ncommit\n");
 	return 0;
-};
+}
 
 int
 bgpq4_print_cisco_eacl(FILE* f, struct bgpq_expander* b)
@@ -1691,10 +1691,10 @@ bgpq4_print_cisco_eacl(FILE* f, struct bgpq_expander* b)
 	} else {
 		fprintf(f, "! generated access-list %s is empty\n", bname);
 		fprintf(f, "ip access-list extended %s deny any any\n", bname);
-	};
+	}
 
 	return 0;
-};
+}
 
 int
 bgpq4_print_nokia_ipprefixlist(FILE* f, struct bgpq_expander* b)
@@ -1711,12 +1711,12 @@ bgpq4_print_nokia_ipprefixlist(FILE* f, struct bgpq_expander* b)
 		sx_radix_tree_foreach(b->tree, bgpq4_print_nokia_ipfilter, f);
 	} else {
 		fprintf(f, "# generated ip-prefix-list %s is empty\n", bname);
-	};
+	}
 
 	fprintf(f,"exit\n");
 
 	return 0;
-};
+}
 
 int
 bgpq4_print_nokia_md_prefixlist(FILE* f, struct bgpq_expander* b)
@@ -1734,12 +1734,12 @@ bgpq4_print_nokia_md_prefixlist(FILE* f, struct bgpq_expander* b)
 	} else {
 		fprintf(f,"# generated %s-prefix-list %s is empty\n",
 		    b->tree->family == AF_INET ? "ip" : "ipv6", bname);
-	};
+	}
 
 	fprintf(f,"}\n");
 
 	return 0;
-};
+}
 
 int
 bgpq4_print_nokia_md_ipprefixlist(FILE* f, struct bgpq_expander* b)
@@ -1753,12 +1753,12 @@ bgpq4_print_nokia_md_ipprefixlist(FILE* f, struct bgpq_expander* b)
 
 	if (!sx_radix_tree_empty(b->tree)) {
 		sx_radix_tree_foreach(b->tree, bgpq4_print_nokia_md_prefix, f);
-	};
+	}
 
 	fprintf(f,"}\n");
 
 	return 0;
-};
+}
 
 void
 bgpq4_print_kprefix(struct sx_radix_node* n, void* ff)
@@ -1787,19 +1787,19 @@ bgpq4_print_kprefix(struct sx_radix_node* n, void* ff)
 			    bname ? bname : "NN",
 			    n->prefix->family == AF_INET ? "V4" : "V6",
 			    prefix, n->aggregateHi);
-		};
+		}
 	} else {
 		fprintf(f,"/routing filter add action=accept chain=\""
 		    "%s-%s\" prefix=%s\n",
 		    bname ? bname : "NN",
 		    n->prefix->family == AF_INET ? "V4" : "V6",
 		    prefix);
-	};
+	}
 
 checkSon:
 	if (n->son)
 		bgpq4_print_kprefix(n->son,ff);
-};
+}
 
 int
 bgpq4_print_mikrotik_prefixlist(FILE* f, struct bgpq_expander* b)
@@ -1810,10 +1810,10 @@ bgpq4_print_mikrotik_prefixlist(FILE* f, struct bgpq_expander* b)
 		sx_radix_tree_foreach(b->tree, bgpq4_print_kprefix, f);
 	} else {
 		fprintf(f, "# generated prefix-list %s is empty\n", bname);
-	};
+	}
 
 	return 0;
-};
+}
 
 int
 bgpq4_print_prefixlist(FILE* f, struct bgpq_expander* b)
@@ -1841,10 +1841,10 @@ bgpq4_print_prefixlist(FILE* f, struct bgpq_expander* b)
 		return bgpq4_print_huawei_prefixlist(f, b);
 	case V_MIKROTIK:
 		return bgpq4_print_mikrotik_prefixlist(f, b);
-	};
+	}
 
 	return 0;
-};
+}
 
 int
 bgpq4_print_eacl(FILE* f, struct bgpq_expander* b)
@@ -1872,10 +1872,10 @@ bgpq4_print_eacl(FILE* f, struct bgpq_expander* b)
 		return sx_report(SX_FATAL, "unreachable point\n");
 	case V_HUAWEI:
 		return sx_report(SX_FATAL, "unreachable point\n");
-	};
+	}
 
 	return 0;
-};
+}
 
 int
 bgpq4_print_juniper_route_filter_list(FILE* f, struct bgpq_expander* b)
@@ -1889,12 +1889,12 @@ bgpq4_print_juniper_route_filter_list(FILE* f, struct bgpq_expander* b)
 	} else {
 		jrfilter_prefixed = 0;
 		sx_radix_tree_foreach(b->tree,bgpq4_print_jrfilter,f);
-	};
+	}
 
 	fprintf(f, "  }\n}\n");
 
 	return 0;
-};
+}
 
 int
 bgpq4_print_route_filter_list(FILE* f, struct bgpq_expander* b)
@@ -1904,7 +1904,7 @@ bgpq4_print_route_filter_list(FILE* f, struct bgpq_expander* b)
 		return bgpq4_print_juniper_route_filter_list(f, b);
 	default:
 		sx_report(SX_FATAL, "unreachable point\n");
-	};
+	}
 
 	return 0;
-};
+}

--- a/bgpq_expander.c
+++ b/bgpq_expander.c
@@ -35,7 +35,7 @@ static inline int
 tentry_cmp(struct sx_tentry* a, struct sx_tentry* b)
 {
 	return strcasecmp(a->text, b->text);
-};
+}
 
 RB_GENERATE(tentree, sx_tentry, entry, tentry_cmp);
 
@@ -64,7 +64,7 @@ bgpq_expander_init(struct bgpq_expander* b, int af)
 		sx_report(SX_FATAL,"Unable to allocate 8192 bytes: %s\n",
 		    strerror(errno));
 		exit(1);
-	};
+	}
 	memset(b->asn32s[0], 0, 8192);
 	b->identify = 1;
 	b->server = "rr.ntt.net";
@@ -90,7 +90,7 @@ fixups:
 	free(b);
 
 	return 0;
-};
+}
 
 int
 bgpq_expander_add_asset(struct bgpq_expander* b, char* as)
@@ -105,7 +105,7 @@ bgpq_expander_add_asset(struct bgpq_expander* b, char* as)
 	STAILQ_INSERT_TAIL(&b->macroses, le, next);
 
 	return 1;
-};
+}
 
 int
 bgpq_expander_add_rset(struct bgpq_expander* b, char* rs)
@@ -123,7 +123,7 @@ bgpq_expander_add_rset(struct bgpq_expander* b, char* rs)
 	STAILQ_INSERT_TAIL(&b->rsets, le, next);
 
 	return 1;
-};
+}
 
 int
 bgpq_expander_add_already(struct bgpq_expander* b, char* rs)
@@ -139,7 +139,7 @@ bgpq_expander_add_already(struct bgpq_expander* b, char* rs)
 	RB_INSERT(tentree, &b->already, le);
 
 	return 1;
-};
+}
 
 int
 bgpq_expander_add_stop(struct bgpq_expander* b, char* rs)
@@ -155,7 +155,7 @@ bgpq_expander_add_stop(struct bgpq_expander* b, char* rs)
 	RB_INSERT(tentree, &b->stoplist, le);
 
 	return 1;
-};
+}
 
 int
 bgpq_expander_add_as(struct bgpq_expander* b, char* as)
@@ -171,7 +171,7 @@ bgpq_expander_add_as(struct bgpq_expander* b, char* as)
 		sx_report(SX_ERROR,"Invalid symbol in AS number: '%c' in %s\n",
 		    *eoa, as);
 		return 0;
-	};
+	}
 
 	if (*eoa == '.' || asno > 65535) {
 		if (b->asn32 || b->generation >= T_PREFIXLIST) {
@@ -184,7 +184,7 @@ bgpq_expander_add_as(struct bgpq_expander* b, char* as)
 			} else {
 				sx_report(SX_ERROR, "Invalid AS number: '%s'\n", as);
 				return 0;
-			};
+			}
 
 			if (eoa && *eoa!=0)
 			    sx_report(SX_ERROR,"Invalid symbol in AS number: '%c' in %s\n",
@@ -194,7 +194,7 @@ bgpq_expander_add_as(struct bgpq_expander* b, char* as)
 			if (asn1 > 65535) {
 				sx_report(SX_ERROR, "Invalid AS number in %s\n", as);
 				return 0;
-			};
+			}
 
 			if (!expand_special_asn && (((asno * 65536 + asn1) >= 4200000000ul) ||
 			    ((asno * 65536 + asn1) >= 64496 && (asno * 65536 + asn1) <= 65551)))
@@ -207,23 +207,23 @@ bgpq_expander_add_as(struct bgpq_expander* b, char* as)
 					    " Unable to add asn32 %s to future expansion\n",
 					    strerror(errno), as);
 					return 0;
-				};
+				}
 				memset(b->asn32s[asno], 0, 8192);
-			};
+			}
 
 			b->asn32s[asno][asn1/8] |= (0x80 >> (asn1 % 8));
 
 		} else if (!b->asn32) {
 			b->asn32s[0][23456/8] |= (0x80 >> (23456 % 8));
-		};
+		}
 
 		return 1;
-	};
+	}
 
 	if (asno < 1 || asno > 65535) {
 		sx_report(SX_ERROR,"Invalid AS number in %s\n", as);
 		return 0;
-	};
+	}
 
 	if (!expand_special_asn && (asno >= 64496 && asno <= 65536))
 		return 0;
@@ -231,7 +231,7 @@ bgpq_expander_add_as(struct bgpq_expander* b, char* as)
 	b->asn32s[0][asno / 8] |= (0x80 >> (asno % 8));
 
 	return 1;
-};
+}
 
 int
 bgpq_expander_add_prefix(struct bgpq_expander* b, char* prefix)
@@ -244,25 +244,25 @@ bgpq_expander_add_prefix(struct bgpq_expander* b, char* prefix)
 		SX_DEBUG(debug_expander, "Ignoring prefix %s with wrong "
 		    "address family\n", prefix);
 		return 0;
-	};
+	}
 	if (b->maxlen && p->masklen>b->maxlen) {
 		SX_DEBUG(debug_expander, "Ignoring prefix %s: masklen %i > max"
 		    " masklen %u\n", prefix, p->masklen, b->maxlen);
 		return 0;
-	};
+	}
 	sx_radix_tree_insert(b->tree,p);
 
         if (p)
 		sx_prefix_destroy(p);
 
 	return 1;
-};
+}
 
 int
 bgpq_expander_add_prefix_range(struct bgpq_expander* b, char* prefix)
 {
 	return sx_prefix_range_parse(b->tree, b->family, b->maxlen, prefix);
-};
+}
 
 int
 bgpq_expanded_macro(char* as, struct bgpq_expander* ex,
@@ -271,7 +271,7 @@ bgpq_expanded_macro(char* as, struct bgpq_expander* ex,
 	bgpq_expander_add_as(ex, as);
 
 	return 1;
-};
+}
 
 struct bgpq_request* bgpq_pipeline(struct bgpq_expander* b,
 	int (*callback)(char*, struct bgpq_expander* b, struct bgpq_request* req),
@@ -291,13 +291,13 @@ bgpq_expanded_macro_limit(char* as, struct bgpq_expander* b,
 			SX_DEBUG(debug_expander>2, "%s is already expanding, "
 			    "ignore\n", as);
 			return 0;
-		};
+		}
 
 		if (RB_FIND(tentree, &b->stoplist, &tkey)) {
 			SX_DEBUG(debug_expander>2, "%s is in the stoplist, "
 			    "ignore\n", as);
 			return 0;
-		};
+		}
 
 		if (!b->maxdepth ||
 		    (b->cdepth + 1 < b->maxdepth &&
@@ -313,12 +313,12 @@ bgpq_expanded_macro_limit(char* as, struct bgpq_expander* b,
 				bgpq_expand_irrd(b, bgpq_expanded_macro_limit,
 				    NULL, "!i%s\n", as);
 				b->cdepth--;
-			};
+			}
 		} else {
 			SX_DEBUG(debug_expander>2, "ignoring %s at depth %i\n",
 			    as,
 			    b->cdepth ? (b->cdepth + 1) : (req->depth + 1));
-		};
+		}
 	} else if (!strncasecmp(as, "AS", 2)) {
 		struct sx_tentry tkey = { .text = as };
 
@@ -326,7 +326,7 @@ bgpq_expanded_macro_limit(char* as, struct bgpq_expander* b,
 			SX_DEBUG(debug_expander > 2,
 			    "%s is in the stoplist, ignore\n", as);
 			return 0;
-		};
+		}
 
 		if (bgpq_expander_add_as(b, as)) {
 			SX_DEBUG(debug_expander > 2, ".. added asn %s\n", as);
@@ -343,7 +343,7 @@ bgpq_expanded_macro_limit(char* as, struct bgpq_expander* b,
 		    req->request);
 
 	return 1;
-};
+}
 
 int
 bgpq_expanded_prefix(char* as, struct bgpq_expander* ex,
@@ -357,7 +357,7 @@ bgpq_expanded_prefix(char* as, struct bgpq_expander* ex,
 		bgpq_expander_add_prefix_range(ex, as);
 
 	return 1;
-};
+}
 
 int
 bgpq_expanded_v6prefix(char* prefix, struct bgpq_expander* ex,
@@ -371,7 +371,7 @@ bgpq_expanded_v6prefix(char* prefix, struct bgpq_expander* ex,
 		bgpq_expander_add_prefix_range(ex, prefix);
 
 	return 1;
-};
+}
 
 int bgpq_pipeline_dequeue(int fd, struct bgpq_expander* b);
 
@@ -392,7 +392,7 @@ bgpq_request_alloc(char* request, int (*callback)(char*, struct bgpq_expander*,
 	bp->udata = udata;
 
 	return bp;
-};
+}
 
 static void
 bgpq_request_free(struct bgpq_request* req)
@@ -401,7 +401,7 @@ bgpq_request_free(struct bgpq_request* req)
 		free(req->request);
 
 	free(req);
-};
+}
 
 struct bgpq_request*
 bgpq_pipeline(struct bgpq_expander* b,
@@ -426,7 +426,7 @@ bgpq_pipeline(struct bgpq_expander* b,
 		    (unsigned long)sizeof(struct bgpq_request),
 		    strerror(errno));
 		exit(1);
-	};
+	}
 
 	if (STAILQ_EMPTY(&b->wq)) {
 		ret = write(b->fd, request, bp->size);
@@ -434,21 +434,21 @@ bgpq_pipeline(struct bgpq_expander* b,
 			if (errno == EAGAIN) {
 				STAILQ_INSERT_TAIL(&b->wq, bp, next);
 				return bp;
-			};
+			}
 			sx_report(SX_FATAL, "Error writing request: %s\n",
 			    strerror(errno));
-		};
+		}
 		bp->offset=ret;
 		if (ret == bp->size) {
 			STAILQ_INSERT_TAIL(&b->rq, bp, next);
 		} else {
 			STAILQ_INSERT_TAIL(&b->wq, bp, next);
-		};
+		}
 	} else
 		STAILQ_INSERT_TAIL(&b->wq, bp, next);
 
 	return bp;
-};
+}
 
 static void
 bgpq_expander_invalidate_asn(struct bgpq_expander* b, const char* q)
@@ -461,7 +461,7 @@ bgpq_expander_invalidate_asn(struct bgpq_expander* b, const char* q)
 			sx_report(SX_ERROR, "some problem invalidating asn"
 			    " %s\n", q);
 			return;
-		};
+		}
 		asn1 = asn % 65536;
 		asn0 = asn / 65536;
 		if (!b->asn32s[asn0] ||
@@ -470,9 +470,9 @@ bgpq_expander_invalidate_asn(struct bgpq_expander* b, const char* q)
 			    "asn %lu(%s)\n", asn, q);
 		} else {
 			b->asn32s[asn0][asn1 / 8] &= ~(0x80 >> (asn1 % 8));
-		};
-	};
-};
+		}
+	}
+}
 
 static void
 bgpq_write(struct bgpq_expander* b)
@@ -488,7 +488,7 @@ bgpq_write(struct bgpq_expander* b)
 				return;
 			sx_report(SX_FATAL, "error writing data: %s\n",
 			    strerror(errno));
-		};
+		}
 
 		if (ret == req->size - req->offset) {
 			/* this request was dequeued */
@@ -497,9 +497,9 @@ bgpq_write(struct bgpq_expander* b)
 		} else {
 			req->offset += ret;
 			break;
-		};
-	};
-};
+		}
+	}
+}
 
 static int
 bgpq_selread(struct bgpq_expander* b, char* buffer, int size)
@@ -533,7 +533,7 @@ repeat:
 		return read(b->fd, buffer, size);
 
 	goto repeat;
-};
+}
 
 int
 bgpq_read(struct bgpq_expander* b)
@@ -563,7 +563,7 @@ repeat:
 			    "%s (dequeue)\n", strerror(errno));
 		} else if (ret == 0) {
 			sx_report(SX_FATAL,"EOF from IRRd (dequeue)\n");
-		};
+		}
 		off += ret;
 
 		if (!(cres = strchr(response, '\n')))
@@ -582,7 +582,7 @@ have:
 			if (!recvbuffer) {
 				sx_report(SX_FATAL, "error allocating %lu "
 				    "bytes: %s\n", togot + 2, strerror(errno));
-			};
+			}
 
 			memset(recvbuffer,0,togot+2);
 
@@ -591,7 +591,7 @@ have:
 				    " char '%c'(%s)\n", eon ? *eon : '0',
 				    response);
 				exit(1);
-			};
+			}
 
 			if (off - ((eon + 1) - response) > togot) {
 				// full response and more data is already in buffer
@@ -609,7 +609,7 @@ have:
 				offset = off - ((eon+1) - response);
 				memset(response, 0, sizeof(response));
 				off = 0;
-			};
+			}
 
 			SX_DEBUG(debug_expander>5,
 			    "starting read with ready '%.*s', waiting for "
@@ -631,7 +631,7 @@ reread:
 			} else if (ret == 0) {
 				sx_report(SX_FATAL,"EOF from IRRd (dequeue, "
 				    "result)\n");
-			};
+			}
 			SX_DEBUG(debug_expander > 5,
 				"Read1: got '%.*s'\n", ret,
 				    recvbuffer + offset);
@@ -641,7 +641,7 @@ reread:
 				    "%lu expanding %s", togot,
 				    strlen(recvbuffer), req->request);
 				goto reread;
-			};
+			}
 
 reread2:
 			ret = bgpq_selread(b, response + off,
@@ -655,7 +655,7 @@ reread2:
 			} else if (ret == 0) {
 				sx_report(SX_FATAL,"EOF from IRRd (dequeue,"
 				    "final)\n");
-			};
+			}
 
 			SX_DEBUG(debug_expander > 5,
 				"Read2: got '%.*s'\n", ret, response + off);
@@ -679,7 +679,7 @@ have3:
 					break;
 				req->callback(c, b, req);
 				c += spn+1;
-			};
+			}
 			assert(c == recvbuffer + togot);
 			memset(recvbuffer, 0, togot + 2);
 			free(recvbuffer);
@@ -705,7 +705,7 @@ have3:
 			sx_report(SX_ERROR,"Wrong reply: %s to %s\n", response,
 			    req->request);
 			exit(1);
-		};
+		}
 
 		memmove(response, cres + 1, off - ((cres + 1) - response));
 		off -= (cres+1) - response;
@@ -717,10 +717,10 @@ have3:
 		b->piped--;
 
 		bgpq_request_free(req);
-	};
+	}
 
 	return 0;
-};
+}
 
 int
 bgpq_expand_irrd(struct bgpq_expander* b,
@@ -745,7 +745,7 @@ bgpq_expand_irrd(struct bgpq_expander* b,
 		sx_report(SX_FATAL,"Partial write to IRRd, only %i bytes "
 		    "written: %s\n", ret, strerror(errno));
 		exit(1);
-	};
+	}
 	memset(response, 0, sizeof(response));
 
 repeat:
@@ -757,7 +757,7 @@ repeat:
 	} else if (ret == 0) {
 		sx_report(SX_FATAL, "EOF reading IRRd\n");
 		exit(1);
-	};
+	}
 
 	off += ret;
 
@@ -776,13 +776,13 @@ repeat:
 		if (!recvbuffer) {
 			sx_report(SX_FATAL, "Error allocating %lu bytes: %s\n",
 			    togot + 2, strerror(errno));
-		};
+		}
 
 		if (eon && *eon != '\n') {
 			sx_report(SX_ERROR,"A-code finised with wrong char "
 			    "'%c' (%s)\n", *eon,response);
 			exit(1);
-		};
+		}
 
 		if (off - ((eon + 1)-response) > togot) {
 			memcpy(recvbuffer, eon+1, togot);
@@ -797,7 +797,7 @@ repeat:
 			offset = off - ((eon + 1) - response);
 			memset(response, 0, sizeof(response));
 			off = 0;
-		};
+		}
 
 		if (off > 0)
 			goto have3;
@@ -811,7 +811,7 @@ reread:
 		} else if (ret < 0) {
 			sx_report(SX_FATAL,"Error reading IRRd: %s "
 			    "(expand,result)\n", strerror(errno));
-		};
+		}
 		offset += ret;
 		if (offset < togot)
 			goto reread;
@@ -825,7 +825,7 @@ reread2:
 		} else if (ret == 0) {
 			sx_report(SX_FATAL, "eof reading IRRd\n");
 			exit(1);
-		};
+		}
 		off += ret;
 
 have3:
@@ -846,7 +846,7 @@ have3:
 			if (callback)
 				callback(c, b, req);
 			c += spn + 1;
-		};
+		}
 		memset(recvbuffer, 0, togot + 2);
 		free(recvbuffer);
 	} else if (response[0] == 'C') {
@@ -864,11 +864,11 @@ have3:
 	} else {
 		sx_report(SX_ERROR,"Wrong reply: %s\n", response);
 		exit(0);
-	};
+	}
 	bgpq_request_free(req);
 
 	return 0;
-};
+}
 
 int
 bgpq_expand(struct bgpq_expander* b)
@@ -890,7 +890,7 @@ bgpq_expand(struct bgpq_expander* b)
 		sx_report(SX_ERROR,"Unable to resolve %s: %s\n", b->server,
 		    gai_strerror(err));
 		exit(1);
-	};
+	}
 
 	for (rp=res; rp; rp = rp->ai_next) {
 		fd = socket(rp->ai_family, rp->ai_socktype, 0);
@@ -900,7 +900,7 @@ bgpq_expand(struct bgpq_expander* b)
 			sx_report(SX_ERROR,"Unable to create socket: %s\n",
 			    strerror(errno));
 			exit(1);
-		};
+		}
 		if (setsockopt(fd, SOL_SOCKET, SO_LINGER, &sl,
 		    sizeof(struct linger))) {
 			sx_report(SX_ERROR,"Unable to set linger on socket: "
@@ -908,14 +908,14 @@ bgpq_expand(struct bgpq_expander* b)
 			shutdown(fd, SHUT_RDWR);
 			close(fd);
 			exit(1);
-		};
+		}
 		err = connect(fd, rp->ai_addr, rp->ai_addrlen);
 		if (err) {
 			shutdown(fd, SHUT_RDWR);
 			close(fd);
 			fd = -1;
 			continue;
-		};
+		}
 		err = sx_maxsockbuf(fd, SO_SNDBUF);
 		if (err > 0) {
 			SX_DEBUG(debug_expander, "Acquired sendbuf of %i "
@@ -925,9 +925,9 @@ bgpq_expand(struct bgpq_expander* b)
 			close(fd);
 			fd = -1;
 			continue;
-		};
+		}
 		break;
-	};
+	}
 
 	freeaddrinfo(res);
 
@@ -936,7 +936,7 @@ bgpq_expand(struct bgpq_expander* b)
 		sx_report(SX_ERROR,"All attempts to connect %s failed, last"
 		    " error: %s\n", b->server, strerror(errno));
 		exit(1);
-	};
+	}
 
 	b->fd = fd;
 
@@ -944,14 +944,14 @@ bgpq_expand(struct bgpq_expander* b)
 		sx_report(SX_ERROR,"Partial write to IRRd: %i bytes, %s\n",
 		    ret, strerror(errno));
 		exit(1);
-	};
+	}
 
 	if (b->identify) {
 		char ident[128];
 		snprintf(ident, sizeof(ident), "!n" PACKAGE_STRING "\n");
 		write(fd, ident, strlen(ident));
 		read(fd, ident, sizeof(ident));
-	};
+	}
 
 	/* Test whether the server has support for the A query */
 	if (b->generation >= T_PREFIXLIST) {
@@ -983,8 +983,8 @@ bgpq_expand(struct bgpq_expander* b)
 			sx_report(SX_ERROR, "Invalid source(s) '%s': %s\n",
 			    b->sources, sources);
 			exit(1);
-		};
-	};
+		}
+	}
 
 	if (pipelining)
 		fcntl(fd, F_SETFL, O_NONBLOCK|(fcntl(fd, F_GETFL)));
@@ -1007,15 +1007,15 @@ bgpq_expand(struct bgpq_expander* b)
 			else
 				bgpq_expand_irrd(b, bgpq_expanded_macro_limit,
 				    NULL, "!i%s\n", mc->text);
-		};
-	};
+		}
+	}
 
 	if (pipelining) {
 		if (!STAILQ_EMPTY(&b->wq))
 			bgpq_write(b);
 		if (!STAILQ_EMPTY(&b->rq))
 			bgpq_read(b);
-	};
+	}
 
 	if (b->generation >= T_PREFIXLIST || b->validate_asns) {
 		uint32_t i, j, k;
@@ -1026,7 +1026,7 @@ bgpq_expand(struct bgpq_expander* b)
 			else
 				bgpq_expand_irrd(b, bgpq_expanded_v6prefix,
 				    NULL, "!i%s,1\n", mc->text);
-		};
+		}
 		for (k=0; k < sizeof(b->asn32s) / sizeof(unsigned char*); k++) {
 			if (!b->asn32s[k])
 				continue;
@@ -1040,7 +1040,7 @@ bgpq_expand(struct bgpq_expander* b)
 							} else {
 								bgpq_pipeline(b, bgpq_expanded_v6prefix,
 								    NULL, "!6as%" PRIu32 "\n", (k << 16) + i * 8 + j);
-							};
+							}
 						} else {
 							if (!pipelining) {
 								bgpq_expand_irrd(b, bgpq_expanded_prefix,
@@ -1048,29 +1048,29 @@ bgpq_expand(struct bgpq_expander* b)
 							} else {
 								bgpq_pipeline(b, bgpq_expanded_prefix,
 								    NULL, "!gas%" PRIu32 "\n", ( k<< 16) + i* 8 + j);
-							};
-						};
-					};
-				};
-			};
-		};
+							}
+						}
+					}
+				}
+			}
+		}
 		if (pipelining) {
 			if (!STAILQ_EMPTY(&b->wq))
 				bgpq_write(b);
 			if (!STAILQ_EMPTY(&b->rq))
 				bgpq_read(b);
-		};
-	};
+		}
+	}
 
 	write(fd, "!q\n",3);
 	if (pipelining) {
 		int fl = fcntl(fd, F_GETFL);
 		fl &= ~O_NONBLOCK;
 		fcntl(fd, F_SETFL, fl);
-	};
+	}
 	shutdown(fd, SHUT_RDWR);
 	close(fd);
 
 	return 1;
-};
+}
 

--- a/sx_maxsockbuf.c
+++ b/sx_maxsockbuf.c
@@ -27,7 +27,7 @@ sx_maxsockbuf(int s, int dir)
 		sx_report(SX_FATAL,"Unable to maximize sockbuf on invalid "
 		    "socket %i\n", s);
 		exit(1);
-	};
+	}
 
 	voptlen = sizeof(optval);
 
@@ -35,7 +35,7 @@ sx_maxsockbuf(int s, int dir)
 		sx_report(SX_ERROR,"initial getsockopt failed: %s\n",
 		    strerror(errno));
 		return -1;
-	};
+	}
 
 	for (;;) { 
 		iterations++;
@@ -46,7 +46,7 @@ sx_maxsockbuf(int s, int dir)
 			if (optval == (hiconf + loconf) / 2)
 				break;
 			optval = (hiconf + loconf) / 2;
-		};
+		}
 
 		if (optval > SX_MAXSOCKBUF_MAX && phase == 0) 
 			break;
@@ -62,7 +62,7 @@ sx_maxsockbuf(int s, int dir)
 			continue;
 		} else { 
 			loconf = optval;
-		};
+		}
 
 		voptlen = sizeof(voptval);
 
@@ -89,8 +89,8 @@ sx_maxsockbuf(int s, int dir)
 			 * case OS permits it
 			 */
 			break;
-		};
-	};
+		}
+	}
 
 	voptlen = sizeof(voptval);
 	if (getsockopt(s, SOL_SOCKET, dir, (void*)&voptval,
@@ -103,7 +103,7 @@ sx_maxsockbuf(int s, int dir)
 		printf("Finally got %i bytes of recvspace in %i interations\n", 
 			voptval, iterations);
 		*/
-	};
+	}
 
 	return voptval;
-};
+}

--- a/sx_prefix.c
+++ b/sx_prefix.c
@@ -29,14 +29,14 @@ sx_prefix_alloc(struct sx_prefix* p)
 		memset(sp, 0, sizeof(struct sx_prefix));
 
 	return sp;
-};
+}
 
 void
 sx_prefix_destroy(struct sx_prefix* p)
 {
 	if (p)
 		free(p);
-};
+}
 
 void
 sx_radix_node_destroy(struct sx_radix_node *n)
@@ -50,7 +50,7 @@ sx_radix_node_destroy(struct sx_radix_node *n)
 
     		free(n);
 	}
-};
+}
 
 void
 sx_prefix_adjust_masklen(struct sx_prefix* p)
@@ -63,12 +63,12 @@ sx_prefix_adjust_masklen(struct sx_prefix* p)
 
 	for (i = nbytes -1; i > p->masklen / 8; i--) {
 		p->addr.addrs[i]=0;
-	};
+	}
 
 	for (i = 1; i <= 8 - p->masklen % 8; i++) {
 		p->addr.addrs[p->masklen / 8] &= (0xff << i);
-	};
-};
+	}
+}
 
 void
 sx_prefix_mask(struct sx_prefix* p, struct sx_prefix* q)
@@ -85,7 +85,7 @@ sx_prefix_mask(struct sx_prefix* p, struct sx_prefix* q)
 
 	for (i = 1; i <= p->masklen % 8; i++)
 		q->addr.addrs[p->masklen / 8] |= (1 << (8 - i));
-};
+}
 
 void
 sx_prefix_imask(struct sx_prefix* p, struct sx_prefix* q)
@@ -102,7 +102,7 @@ sx_prefix_imask(struct sx_prefix* p, struct sx_prefix* q)
 
 	for (i = 1;i <= p->masklen % 8; i++)
 		q->addr.addrs[p->masklen / 8] &= ~(1 <<(8 - i));
-};
+}
 
 
 int
@@ -125,17 +125,17 @@ sx_prefix_parse(struct sx_prefix* p, int af, char* text)
 			sx_report(SX_ERROR, "Invalid masklen in prefix %s\n",
 			    text);
 			goto fixups;
-		};
+		}
 	} else {
 		masklen = -1;
-	};
+	}
 
 	if (!af) {
 		if (strchr(mtext, ':'))
 			af = AF_INET6;
 		else
 			af = AF_INET;
-	};
+	}
 
 	ret = inet_pton(af, mtext, &p->addr);
 
@@ -162,8 +162,8 @@ sx_prefix_parse(struct sx_prefix* p, int af, char* text)
 			    " (%s), ret=%i\n", mtext, af,
 			    af == AF_INET ? "inet" : "inet6", ret);
 			goto fixups;
-		};
-	};
+		}
+	}
 
 	if (af == AF_INET) {
 		if (masklen == -1)
@@ -173,8 +173,8 @@ sx_prefix_parse(struct sx_prefix* p, int af, char* text)
 				p->masklen = 32;
 			} else {
 				p->masklen = masklen;
-			};
-		};
+			}
+		}
 	} else if (af == AF_INET6) {
 		if (masklen == -1)
 			p->masklen = 128;
@@ -183,12 +183,12 @@ sx_prefix_parse(struct sx_prefix* p, int af, char* text)
 				p->masklen = 128;
 			} else {
 				p->masklen = masklen;
-			};
-		};
+			}
+		}
 	} else {
 		sx_report(SX_ERROR, "Invalid address family %i\n", af);
 		goto fixups;
-	};
+	}
 
 	p->family = af;
 	sx_prefix_adjust_masklen(p);
@@ -200,7 +200,7 @@ sx_prefix_parse(struct sx_prefix* p, int af, char* text)
 
 fixups:
 	return 0;
-};
+}
 
 int
 sx_prefix_isbitset(struct sx_prefix* p, int n)
@@ -215,7 +215,7 @@ sx_prefix_isbitset(struct sx_prefix* p, int n)
 	s = p->addr.addrs[(n - 1) / 8];
 
 	return (s & (0x80 >> ((n - 1) % 8))) ? 1 : 0;
-};
+}
 
 void
 sx_prefix_setbit(struct sx_prefix* p, int n)
@@ -230,7 +230,7 @@ sx_prefix_setbit(struct sx_prefix* p, int n)
 	s = p->addr.addrs + (n - 1) / 8;
 
 	(*s) |= 0x80 >> ((n - 1) % 8);
-};
+}
 
 
 int
@@ -255,7 +255,7 @@ sx_radix_tree_insert_specifics(struct sx_radix_tree* t, struct sx_prefix *p,
 	sx_radix_tree_insert_specifics(t, np, min, max);
 
 	return 1;
-};
+}
 
 int
 sx_prefix_range_parse(struct sx_radix_tree* tree, int af, int maxlen,
@@ -276,7 +276,7 @@ sx_prefix_range_parse(struct sx_radix_tree* tree, int af, int maxlen,
 		sx_report(SX_ERROR, "Unable to parse prefix %s^%s\n", text,
 		    d+1);
 		return 0;
-	};
+	}
 
 	*d = '^';
 
@@ -284,13 +284,13 @@ sx_prefix_range_parse(struct sx_radix_tree* tree, int af, int maxlen,
 		sx_report(SX_ERROR, "Ignoring prefix %s, wrong af %i\n", text,
 		    p->family);
 		return 0;
-	};
+	}
 
 	if (maxlen && p->masklen > maxlen) {
 		SX_DEBUG(debug_expander, "Ignoring prefix %s, masklen %i > max"
 		    " masklen %u\n", text, p->masklen, maxlen);
 		return 0;
-	};
+	}
 
 	if (d[1] == '-') {
 		min = p->masklen + 1;
@@ -307,17 +307,17 @@ sx_prefix_range_parse(struct sx_radix_tree* tree, int af, int maxlen,
 			sx_report(SX_ERROR, "Unable to parse prefix-range "
 			    "%s\n", text);
 			return 0;
-		};
+		}
 	} else {
 		sx_report(SX_ERROR, "Invalid prefix-range %s\n", text);
 		return 0;
-	};
+	}
 
 	if (min < p->masklen) {
 		sx_report(SX_ERROR, "Invalid prefix-range %s: min %lu < "
 		    "masklen %u\n", text, min, p->masklen);
 		return 0;
-	};
+	}
 
 	if (af == AF_INET && max > 32) {
 		sx_report(SX_ERROR, "Invalid prefix-range %s: max %lu > "
@@ -327,7 +327,7 @@ sx_prefix_range_parse(struct sx_radix_tree* tree, int af, int maxlen,
 		sx_report(SX_ERROR, "Invalid ipv6 prefix-range %s: max %lu > "
 		    "128\n", text, max);
 		return 0;
-	};
+	}
 
 	if (max > maxlen)
 		max = maxlen;
@@ -338,7 +338,7 @@ sx_prefix_range_parse(struct sx_radix_tree* tree, int af, int maxlen,
 	sx_radix_tree_insert_specifics(tree, p, min, max);
 
 	return 1;
-};
+}
 
 struct sx_prefix*
 sx_prefix_new(int af, char* text)
@@ -356,10 +356,10 @@ sx_prefix_new(int af, char* text)
 	if (!sx_prefix_parse(p, af, text)) {
 		sx_prefix_destroy(p);
 		return NULL;
-	};
+	}
 
 	return p;
-};
+}
 
 int
 sx_prefix_fprint(FILE* f, struct sx_prefix* p)
@@ -369,11 +369,11 @@ sx_prefix_fprint(FILE* f, struct sx_prefix* p)
 	if (!p) {
 		fprintf(f?f:stdout,"(null)");
 		return 0;
-	};
+	}
 
 	inet_ntop(p->family, &p->addr, buffer, sizeof(buffer));
 	return fprintf( f ? f : stdout, "%s/%i", buffer, p->masklen);
-};
+}
 
 int
 sx_prefix_snprintf_sep(struct sx_prefix* p, char* rbuffer, int srb, char* sep)
@@ -386,18 +386,18 @@ sx_prefix_snprintf_sep(struct sx_prefix* p, char* rbuffer, int srb, char* sep)
 	if (!p) {
 		snprintf(rbuffer, srb, "(null)");
 		return 0;
-	};
+	}
 
 	inet_ntop(p->family, &p->addr, buffer, sizeof(buffer));
 
 	return snprintf(rbuffer, srb, "%s%s%i", buffer, sep, p->masklen);
-};
+}
 
 int
 sx_prefix_snprintf(struct sx_prefix* p, char* rbuffer, int srb)
 {
 	return sx_prefix_snprintf_sep(p, rbuffer, srb, "/");
-};
+}
 
 int
 sx_prefix_snprintf_fmt(struct sx_prefix* p, char* buffer, int size,
@@ -442,7 +442,7 @@ sx_prefix_snprintf_fmt(struct sx_prefix* p, char* buffer, int size,
 				sx_report(SX_ERROR, "Unknown format char "
 				    "'%c'\n", *(c + 1));
 				return 0;
-			};
+			}
 			c += 2;
 		} else if (*c == '\\') {
 			switch(*(c+1)) {
@@ -458,16 +458,16 @@ sx_prefix_snprintf_fmt(struct sx_prefix* p, char* buffer, int size,
 			default:
 				buffer[off++] = *(c + 1);
 				break;
-			};
+			}
 			c += 2;
 		} else {
 			buffer[off++] = *c;
 			c++;
-		};
-	};
+		}
+	}
 
 	return strlen(buffer);
-};
+}
 
 int
 sx_prefix_jsnprintf(struct sx_prefix* p, char* rbuffer, int srb)
@@ -477,11 +477,11 @@ sx_prefix_jsnprintf(struct sx_prefix* p, char* rbuffer, int srb)
 	if (!p) {
 		snprintf(rbuffer, srb, "(null)");
 		return 0;
-	};
+	}
 	inet_ntop(p->family, &p->addr, buffer, sizeof(buffer));
 
 	return snprintf(rbuffer, srb, "%s\\/%i", buffer, p->masklen);
-};
+}
 
 struct sx_radix_tree*
 sx_radix_tree_new(int af)
@@ -495,13 +495,13 @@ sx_radix_tree_new(int af)
 	rt->family = af;
 
 	return rt;
-};
+}
 
 int
 sx_radix_tree_empty(struct sx_radix_tree* t)
 {
 	return t->head == NULL;
-};
+}
 
 struct sx_radix_node*
 sx_radix_node_new(struct sx_prefix* prefix)
@@ -517,7 +517,7 @@ sx_radix_node_new(struct sx_prefix* prefix)
 		rn->prefix = sx_prefix_alloc(prefix);
 
 	return rn;
-};
+}
 
 int
 sx_prefix_eqbits(struct sx_prefix* a, struct sx_prefix* b)
@@ -536,15 +536,15 @@ sx_prefix_eqbits(struct sx_prefix* a, struct sx_prefix* b)
 				if ((a->addr.addrs[i] & (0x80 >> j))
 				    != (b->addr.addrs[i] & (0x80 >> j)))
 					return i * 8 + j;
-			};
-		};
-	};
+			}
+		}
+	}
 
 	if (a->masklen < b->masklen)
 		return a->masklen;
 
 	return b->masklen;
-};
+}
 
 struct sx_prefix*
 sx_prefix_overlay(struct sx_prefix* p, int n)
@@ -554,7 +554,7 @@ sx_prefix_overlay(struct sx_prefix* p, int n)
 	sx_prefix_adjust_masklen(sp);
 
 	return sp;
-};
+}
 
 void
 sx_radix_tree_unlink(struct sx_radix_tree* tree, struct sx_radix_node* node)
@@ -573,7 +573,7 @@ next:
 			} else {
 				sx_report(SX_ERROR,"Unlinking node which is "
 				    "not descendant of its parent\n");
-			};
+			}
 		} else if (tree->head == node) {
 			/* only one case, really */
 			tree->head = node->r;
@@ -581,7 +581,7 @@ next:
 		} else {
 			sx_report(SX_ERROR,"Unlinking node with no parent and"
 			    " not root\n");
-		};
+		}
 		sx_radix_node_destroy(node);
 		return;
 	} else if (node->l) {
@@ -595,13 +595,13 @@ next:
 			} else {
 				sx_report(SX_ERROR,"Unlinking node which is not descendant "
 					"of its parent\n");
-			};
+			}
 		} else if(tree->head==node) {
 			tree->head=node->l;
 			node->l->parent=NULL;
 		} else {
 			sx_report(SX_ERROR,"Unlinking node with no parent and not root\n");
-		};
+		}
 		sx_radix_node_destroy(node);
 		return;
 	} else {
@@ -614,22 +614,22 @@ next:
 			else {
 				sx_report(SX_ERROR,"Unlinking node which is "
 				    "not descendant of its parent\n");
-			};
+			}
 
 			if (node->parent->isGlue) {
 				node = node->parent;
 				goto next;
-			};
+			}
 		} else if (tree->head==node) {
 			tree->head = NULL;
 		} else {
 			sx_report(SX_ERROR, "Unlinking node with no parent and"
 			    " not root\n");
-		};
+		}
 		sx_radix_node_destroy(node);
 		return;
-	};
-};
+	}
+}
 	
 			
 struct sx_radix_node*
@@ -664,27 +664,27 @@ next:
 			if (chead->r) {
 				if (!chead->isGlue) {
 					candidate = chead;
-				};
+				}
 				chead = chead->r;
 				goto next;
 			} else {
 				if (chead->isGlue)
 					return candidate;
 				return chead;
-			};
+			}
 		} else {
 			if (chead->l) {
 				if (!chead->isGlue) {
 					candidate = chead;
-				};
+				}
 				chead = chead->l;
 				goto next;
 			} else {
 				if (chead->isGlue)
 					return candidate;
 				return chead;
-			};
-		};
+			}
+		}
 	} else {
 		char pbuffer[128], cbuffer[128];
 		sx_prefix_snprintf(prefix, pbuffer, sizeof(pbuffer));
@@ -692,8 +692,8 @@ next:
 		printf("Unreachible point... eb=%i, prefix=%s, chead=%s\n",
 		    eb, pbuffer, cbuffer);
 		abort();
-	};
-};
+	}
+}
 
 
 struct sx_radix_node*
@@ -711,7 +711,7 @@ sx_radix_tree_insert(struct sx_radix_tree* tree, struct sx_prefix* prefix)
 	if (!tree->head) {
 		tree->head=sx_radix_node_new(prefix);
 		return tree->head;
-	};
+	}
 
 	candidate = &tree->head;
 	chead = tree->head;
@@ -731,7 +731,7 @@ next:
 			sx_report(SX_ERROR,"Unable to create node: %s\n",
 			    strerror(errno));
 			return NULL;
-		};
+		}
 
 		if (sx_prefix_isbitset(prefix, eb + 1)) {
 			rn->l = chead;
@@ -739,7 +739,7 @@ next:
 		} else {
 			rn->l = ret;
 			rn->r = chead;
-		};
+		}
 
 		rn->parent = chead->parent;
 		chead->parent = rn;
@@ -753,7 +753,7 @@ next:
 			ret->r = chead;
 		} else {
 			ret->l = chead;
-		};
+		}
 		ret->parent = chead->parent;
 		chead->parent = ret;
 		*candidate = ret;
@@ -768,7 +768,7 @@ next:
 				chead->r = sx_radix_node_new(prefix);
 				chead->r->parent = chead;
 				return chead->r;
-			};
+			}
 		} else {
 			if (chead->l) {
 				candidate = &chead->l;
@@ -778,13 +778,13 @@ next:
 				chead->l = sx_radix_node_new(prefix);
 				chead->l->parent = chead;
 				return chead->l;
-			};
-		};
+			}
+		}
 	} else if (eb == chead->prefix->masklen && eb == prefix->masklen) {
 		/* equal routes... */
 		if (chead->isGlue) {
 			chead->isGlue = 0;
-		};
+		}
 		return chead;
 	} else {
 		char pbuffer[128], cbuffer[128];
@@ -793,7 +793,7 @@ next:
 		printf("Unreachible point... eb=%i, prefix=%s, chead=%s\n", eb,
 		    pbuffer, cbuffer);
 		abort();
-	};
+	}
 }
 
 void
@@ -806,8 +806,8 @@ sx_radix_node_fprintf(struct sx_radix_node* node, void* udata)
 	} else {
 		sx_prefix_snprintf(node->prefix, buffer, sizeof(buffer));
 		fprintf(out, "%s %s\n", buffer, node->isGlue ? "(glue)" : "");
-	};
-};
+	}
+}
 
 int
 sx_radix_node_foreach(struct sx_radix_node* node,
@@ -822,7 +822,7 @@ sx_radix_node_foreach(struct sx_radix_node* node,
 		sx_radix_node_foreach(node->r, func, udata);
 
 	return 0;
-};
+}
 
 int
 sx_radix_tree_foreach(struct sx_radix_tree* tree,
@@ -831,7 +831,7 @@ sx_radix_tree_foreach(struct sx_radix_tree* tree,
 	if(!func || !tree || !tree->head) return 0;
 	sx_radix_node_foreach(tree->head,func,udata);
 	return 0;
-};
+}
 
 int
 sx_radix_node_aggregate(struct sx_radix_node* node)
@@ -862,8 +862,8 @@ sx_radix_node_aggregate(struct sx_radix_node* node)
 			    node->r->son->isAggregate ? "Aggregate " : "",
 			    node->r->son->aggregateLow,
 			    node->r->son->aggregateHi);
-			};
-		};
+			}
+		}
 		if (node->l) {
 			printf("L-Tree: ");
 			sx_prefix_fprint(stdout, node->l->prefix);
@@ -878,9 +878,9 @@ sx_radix_node_aggregate(struct sx_radix_node* node)
 				    node->l->son->isAggregate ? "Aggregate " : "",
 				    node->l->son->aggregateLow,
 				    node->l->son->aggregateHi);
-			};
-		};
-	};
+			}
+		}
+	}
 
 	if (node->r && node->l) {
 		if (!node->r->isAggregate && !node->l->isAggregate
@@ -896,8 +896,8 @@ sx_radix_node_aggregate(struct sx_radix_node* node)
 					node->aggregateLow = node->r->prefix->masklen;
 				} else {
 					node->aggregateLow = node->prefix->masklen;
-				};
-			};
+				}
+			}
 			if (node->r->son && node->l->son
 			    && node->r->son->isAggregate
 			    && node->l->son->isAggregate
@@ -912,7 +912,7 @@ sx_radix_node_aggregate(struct sx_radix_node* node)
 				node->son->aggregateLow = node->r->son->aggregateLow;
 				node->r->son->isGlue = 1;
 				node->l->son->isGlue = 1;
-			};
+			}
 		} else if (node->r->isAggregate && node->l->isAggregate
 		    && node->r->aggregateHi == node->l->aggregateHi
 		    && node->r->aggregateLow==node->l->aggregateLow) {
@@ -949,9 +949,9 @@ sx_radix_node_aggregate(struct sx_radix_node* node)
 						node->son->son->aggregateLow = node->r->son->aggregateLow;
 						node->r->son->isGlue = 1;
 						node->l->son->isGlue = 1;
-					};
-				};
-			};
+					}
+				}
+			}
 		} else if (node->l->son && node->r->isAggregate
 		    && node->l->son->isAggregate
 		    && node->r->aggregateHi == node->l->son->aggregateHi
@@ -973,8 +973,8 @@ sx_radix_node_aggregate(struct sx_radix_node* node)
 					node->son->aggregateLow = node->r->aggregateLow;
 					node->r->isGlue = 1;
 					node->l->son->isGlue = 1;
-				};
-			};
+				}
+			}
 		} else if (node->r->son && node->l->isAggregate
 		    && node->r->son->isAggregate
 		    && node->l->aggregateHi == node->r->son->aggregateHi
@@ -996,13 +996,13 @@ sx_radix_node_aggregate(struct sx_radix_node* node)
 					node->son->aggregateLow = node->l->aggregateLow;
 					node->l->isGlue = 1;
 					node->r->son->isGlue = 1;
-				};
-			};
-		};
-	};
+				}
+			}
+		}
+	}
 
 	return 0;
-};
+}
 
 int
 sx_radix_tree_aggregate(struct sx_radix_tree* tree)
@@ -1011,7 +1011,7 @@ sx_radix_tree_aggregate(struct sx_radix_tree* tree)
 		return sx_radix_node_aggregate(tree->head);
 
 	return 0;
-};
+}
 
 static void
 setGlueUpTo(struct sx_radix_node* node, void* udata)
@@ -1020,7 +1020,7 @@ setGlueUpTo(struct sx_radix_node* node, void* udata)
 
 	if (node && node->prefix->masklen <= refine)
 		node->isGlue = 1;
-};
+}
 
 int
 sx_radix_node_refine(struct sx_radix_node* node, unsigned refine)
@@ -1032,11 +1032,11 @@ sx_radix_node_refine(struct sx_radix_node* node, unsigned refine)
 		if (node->l) {
 			sx_radix_node_foreach(node->l, setGlueUpTo, &refine);
 			sx_radix_node_refine(node->l, refine);
-		};
+		}
 		if (node->r) {
 			sx_radix_node_foreach(node->r, setGlueUpTo, &refine);
 			sx_radix_node_refine(node->r, refine);
-		};
+		}
 	} else if (!node->isGlue && node->prefix->masklen == refine) {
 		/* not setting aggregate in this case */
 		if (node->l)
@@ -1060,9 +1060,9 @@ sx_radix_node_refine(struct sx_radix_node* node, unsigned refine)
 		if (node->r)
 			sx_radix_node_foreach(node->r, setGlue, NULL);
 		*/
-	};
+	}
 	return 0;
-};
+}
 	
 int
 sx_radix_tree_refine(struct sx_radix_tree* tree, unsigned refine)
@@ -1071,7 +1071,7 @@ sx_radix_tree_refine(struct sx_radix_tree* tree, unsigned refine)
 		return sx_radix_node_refine(tree->head, refine);
 
 	return 0;
-};
+}
 
 static void
 setGlueFrom(struct sx_radix_node* node, void* udata)
@@ -1080,7 +1080,7 @@ setGlueFrom(struct sx_radix_node* node, void* udata)
 
 	if (node && node->prefix->masklen <= refine)
 		node->isGlue=1;
-};
+}
 
 static int
 sx_radix_node_refineLow(struct sx_radix_node* node, unsigned refineLow)
@@ -1100,12 +1100,12 @@ sx_radix_node_refineLow(struct sx_radix_node* node, unsigned refineLow)
 		if (node->l) {
 			sx_radix_node_foreach(node->l, setGlueFrom, &refineLow);
 			sx_radix_node_refineLow(node->l, refineLow);
-		};
+		}
 
 		if (node->r) {
 			sx_radix_node_foreach(node->r, setGlueFrom, &refineLow);
 			sx_radix_node_refineLow(node->r, refineLow);
-		};
+		}
 
 	} else if (!node->isGlue && node->prefix->masklen == refineLow) {
 		/* not setting aggregate in this case */
@@ -1128,10 +1128,10 @@ sx_radix_node_refineLow(struct sx_radix_node* node, unsigned refineLow)
 		if (node->r)
 			sx_radix_node_foreach(node->r, setGlue, NULL);
 		*/
-	};
+	}
 
 	return 0;
-};
+}
 
 int
 sx_radix_tree_refineLow(struct sx_radix_tree* tree, unsigned refineLow)
@@ -1140,7 +1140,7 @@ sx_radix_tree_refineLow(struct sx_radix_tree* tree, unsigned refineLow)
 		return sx_radix_node_refineLow(tree->head, refineLow);
 
 	return 0;
-};
+}
 
 #if SX_PTREE_TEST
 int
@@ -1310,6 +1310,6 @@ main() {
 	sx_radix_tree_foreach(tree, sx_radix_node_fprintf, NULL);
 
 	return 0;
-};
+}
 
 #endif

--- a/sx_report.c
+++ b/sx_report.c
@@ -29,10 +29,10 @@ sx_report_name(sx_report_t t)
 		return "Notice:";
 	case SX_DEBUG:
 		return "Debug:";
-	};
+	}
 
 	return "...... HMMMMM.... ERROR... \n";
-};
+}
 
 int
 sx_report(sx_report_t t, char* fmt, ...)
@@ -62,14 +62,14 @@ sx_report(sx_report_t t, char* fmt, ...)
 		case SX_DEBUG: 
 			syslog(LOG_DEBUG,"Debug: %s", buffer);
 			break;
-		};
-	};
+		}
+	}
 
 	if (t == SX_FATAL)
 		exit(-1);
 
 	return 0;
-};
+}
 
 int 
 sx_debug(char const* const file, char const* const func, int const line, 
@@ -90,15 +90,15 @@ sx_debug(char const* const file, char const* const func, int const line,
 		fputs(buffer, stderr);
 	} else { 
 		syslog(LOG_DEBUG,"%s %s", bline, buffer);
-	};
+	}
 
 	return 0;
-};
+}
 
 void
 sx_openlog(char* progname)
 { 
 	openlog(progname ? progname : "<unknown>", LOG_PID, LOG_DAEMON);
 	reportStderr = 0;
-};
+}
 

--- a/sx_slentry.c
+++ b/sx_slentry.c
@@ -19,7 +19,7 @@ sx_slentry_new(char* t)
 		e->text = strdup(t);
 
 	return e;
-};
+}
 
 struct sx_tentry*
 sx_tentry_new(char* t)
@@ -33,4 +33,4 @@ sx_tentry_new(char* t)
 	te->text = strdup(t);
 
 	return te;
-};
+}


### PR DESCRIPTION
C does not require `;` after every closing brace, nor does `style(9)` from OpenBSD. This PR removes these non-required `;`.