### PR TITLE
AM_CONFIG_HEADER is superseded by AC_CONFIG_HEADERS since July 2002

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 AC_INIT(bgpq4,0.0.6,job@ntt.net)
 AM_INIT_AUTOMAKE
 AC_PACKAGE_URL(https://github.com/bgp/bgpq4)
-AM_CONFIG_HEADER(config.h)
+AC_CONFIG_HEADERS([config.h])
 AM_SILENT_RULES([yes])
 
 AC_PROG_CC


### PR DESCRIPTION
Reported by @fabaff during Fedora package review.

See: https://lists.gnu.org/archive/html/automake/2012-12/msg00038.html