### PR TITLE
Avoid man page macro warnings

### DIFF
--- a/bgpq4.8
+++ b/bgpq4.8
@@ -134,7 +134,7 @@ those objects will be excluded from expansion.
 .Sh EXAMPLES
 Generating named juniper prefix-filter for AS20597: 
 .nf
-.RS
+.Rs
 $ bgpq4 -Jl eltel AS20597
 policy-options {
 replace:
@@ -154,13 +154,13 @@ replace:
     217.170.80.0/20;
  }
 }
-.RE
+.Re
 .fi
 .Pp
 For Cisco we can use aggregation (-A) flag to make this prefix-filter
 more compact: 
 .nf
-.RS
+.Rs
 $ bgpq4 -Al eltel AS20597
 no ip prefix-list eltel
 ip prefix-list eltel permit 81.9.0.0/20
@@ -174,7 +174,7 @@ ip prefix-list eltel permit 89.112.0.0/18 ge 19 le 19
 ip prefix-list eltel permit 89.112.4.0/22
 ip prefix-list eltel permit 89.112.64.0/19
 ip prefix-list eltel permit 217.170.64.0/19 ge 20 le 20
-.RE
+.Re
 .fi
 - you see, prefixes 89.112.0.0/19 and 89.112.32.0/19 now aggregated
 into single entry 89.112.0.0/18 ge 19 le 19. 
@@ -182,7 +182,7 @@ into single entry 89.112.0.0/18 ge 19 le 19.
 Well, for Juniper we can generate even more interesting policy-options,
 using -M <extra match conditions>, -R <len> and hierarchical names: 
 .nf
-.RS
+.Rs
 $ bgpq4 -AJEl eltel/specifics -r 29 -R 32 -M "community blackhole" AS20597
 policy-options {
  policy-statement eltel {
@@ -203,7 +203,7 @@ replace:
   }
  }
 }
-.RE
+.Re
 .fi
 generated policy-option term now allows all specifics with prefix-length
 between /29 and /32 for eltel networks if they match with special community 
@@ -211,17 +211,17 @@ blackhole (defined elsewhere in configuration).
 .Pp
 Of course, this version supports IPv6 (-6): 
 .nf
-.RS
+.Rs
 $ bgpq4 -6l as-retn-6 AS-RETN6
 no ipv6 prefix-list as-retn-6
 ipv6 prefix-list as-retn-6 permit 2001:7fb:fe00::/48
 ipv6 prefix-list as-retn-6 permit 2001:7fb:fe01::/48
 [....]
-.RE
+.Re
 .fi
 and assumes your device supports 32-bit ASNs
 .nf
-.RS
+.Rs
 $ bgpq4 -Jf 112 AS-SPACENET
 policy-options {
 replace:
@@ -232,7 +232,7 @@ replace:
   as-path a3 "^112(.)*(35052|41720|43628|44450|196611)$";
  }
 }
-.RE
+.Re
 .fi
 see `AS196611` in the end of the list ? That's a 32-bit ASN.
 .Pp
@@ -241,13 +241,13 @@ If you want to generate configuration not for routers, but for some
 other programs/systems, you may use user-defined formatting, like in
 example below:
 .nf
-.RS
+.Rs
 $ bgpq4 -F "ipfw add pass all from %n/%l to any\\n" as3254
 ipfw add pass all from 62.244.0.0/18 to any
 ipfw add pass all from 91.219.29.0/24 to any
 ipfw add pass all from 91.219.30.0/24 to any
 ipfw add pass all from 193.193.192.0/19 to any
-.RE
+.Re
 .fi
 .Pp
 Recognized format characters: %n - network, %l - mask length,
@@ -258,10 +258,10 @@ Please note that no new lines inserted automatically after each sentence,
 you have to add them into format string manually, elsewhere output will
 be in one line (sometimes it makes sense):
 .nf
-.RS
+.Rs
 $ bgpq4 -6F "%n/%l; " as-eltel
 2001:1b00::/32; 2620:4f:8000::/48; 2a04:bac0::/29; 2a05:3a80::/48;
-.RE
+.Re
 .fi
 .Sh DIAGNOSTICS
 When everything is OK, 


### PR DESCRIPTION
Reported by @fabaff during Fedora package review.

```
$ LC_ALL=en_US.UTF-8 MANROFFSEQ='' MANWIDTH=80 man --warnings -E UTF-8 -l -Tutf8 -Z bgpq4.8 > /dev/null
<standard input>:137: warning: macro `RS' not defined
<standard input>:157: warning: macro `RE' not defined
$
```

I am however not absolutely sure whether my taken approach is really correct.