### PR TITLE
bgpq_expander - Increase the read select timeout to 30 seconds

### DIFF
--- a/bgpq_expander.c
+++ b/bgpq_expander.c
@@ -477,7 +477,7 @@ bgpq_selread(struct bgpq_expander* b, char* buffer, int size)
 {
 	fd_set rfd, wfd;
 	int ret;
-	struct timeval timeout = {10, 0};
+	struct timeval timeout = {30, 0};
 
 repeat:
 	FD_ZERO(&rfd);


### PR DESCRIPTION
With the current 10 second timeout I have observed intermittent failures reporting `FATAL ERROR:select timeout` when querying large objects.

This has only been observed when using IRRD instances supporting `A` queries which led me down a path of investigating the server side timeout, the default of which in irrd4 is 30 seconds, thus 30 seconds was chosen as the read timeout (bgpq4 currently has no option to pass `!T`).

The increased timeout has been running as a local patch in my environment for more than two months with no observed failures, testing the upstream version locally still results in intermittent failures.

Commentary on the Github issue indicated ~9 second response times from Europe, which could be related to the higher latency (150ms+) cross region.