### PR TITLE
Respect -s when there are no prefix lists

### DIFF
--- a/bgpq4_printer.c
+++ b/bgpq4_printer.c
@@ -1552,9 +1552,10 @@ bgpq4_print_cisco_prefixlist(FILE* f, struct bgpq_expander* b)
 		sx_radix_tree_foreach(b->tree, bgpq4_print_cprefix, f);
 	} else {
 		fprintf(f, "! generated prefix-list %s is empty\n", bname);
-		fprintf(f, "%s prefix-list %s deny %s\n",
+		fprintf(f, "%s prefix-list %s%s deny %s\n",
 		    b->family==AF_INET ? "ip" : "ipv6",
 		    bname,
+		    seq ? " seq 1" : "",
 		    b->family==AF_INET ? "0.0.0.0/0" : "::/0");
 	}
 
@@ -1615,9 +1616,10 @@ bgpq4_print_huawei_prefixlist(FILE* f, struct bgpq_expander* b)
 	if (!sx_radix_tree_empty(b->tree)) {
 		sx_radix_tree_foreach(b->tree, bgpq4_print_hprefix, f);
 	} else {
-		fprintf(f, "ip %s-prefix %s deny %s\n",
+		fprintf(f, "ip %s-prefix %s%s deny %s\n",
 		    b->family==AF_INET ? "ip" : "ipv6",
 		    bname,
+		    seq ? " seq 1" : "",
 		    b->family==AF_INET ? "0.0.0.0/0" : "::/0");
 	}
 


### PR DESCRIPTION
This pull request fixes a bug that is present when the `-s` argument is passed but there are no results. Previous to this pull request, sequence numbers were not added to the fallback prefix list. Now, when `-s` is passed and no results are present, a sequence order will be present.

For example, with `bgpq4 -S RIPE,ARIN,APNIC,AFRINIC -4 -s -l AS714-IN AS714`:

Before:

```
no ip prefix-list AS714-IN
! generated prefix-list AS714-IN is empty
ip prefix-list AS714-IN deny 0.0.0.0/0
```

After:

```
no ip prefix-list AS714-IN
! generated prefix-list AS714-IN is empty
ip prefix-list AS714-IN seq 1 deny 0.0.0.0/0
```

##

Resolves https://github.com/bgp/bgpq4/issues/33