### PR TITLE
Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM alpine as builder
+
+RUN apk --update --no-cache add build-base autoconf automake
+
+COPY . /build
+WORKDIR /build
+
+RUN ./bootstrap
+RUN ./configure
+RUN make
+RUN make install
+
+FROM alpine
+COPY --from=builder /build/bgpq4 /usr/local/bin
+
+ENTRYPOINT ["/usr/local/bin/bgpq4"]


### PR DESCRIPTION
This pull request adds support for running bgpq4 in Docker. This is particularly helpful in environments where bgpq4 is not distributed in a package manager, or the tools needed compile the application are either unavailable or unwanted. This also offers an alternative to running bgpq4 in MacOS where bgpq4 is not available in homebrew. I can also imagine this to be helpful in Arista EOS where you [can run containers](https://eos.arista.com/docker-containers-on-arista-eos/) directly on the switch. A switch could hypothetically automatically update its own filters on a regular basis.

As this currently stands, it can be built and executed with something like:

```
docker build -t bswinnerton/bgpq4:latest .
docker run bswinnerton/bgpq4:latest AS36459
```

But ideally we would host these images on either [Docker Hub](https://hub.docker.com/) or [GitHub Packages](https://github.com/features/packages) to make it easier for users to do something like:

```
docker pull bgpq4:latest
docker run bgpq4 AS36459
```

This would require some support from the maintainers of this application in order to set up, but once configured, could automatically be updated any time the application is updated, or perhaps any time new releases occur.