### PR TITLE
Juniper route-filter-list output correction

### DIFF
--- a/bgpq4_printer.c
+++ b/bgpq4_printer.c
@@ -1973,7 +1973,7 @@ bgpq4_print_juniper_route_filter_list(FILE* f, struct bgpq_expander* b)
 	    b->name ? b->name : "NN");
 
 	if (sx_radix_tree_empty(b->tree)) {
-		fprintf(f, "    route-filter %s/0 orlonger reject;\n",
+		fprintf(f, "    %s/0 orlonger reject;\n",
 		    b->tree->family == AF_INET ? "0.0.0.0" : "::");
 	} else {
 		jrfilter_prefixed = 0;


### PR DESCRIPTION
I experienced an issue while generating a prefix list for our customer. The JunOS return an error while importing the prefix list to the configuration. 

The latest version output as below:
- Example 1: An AS-SET with route objects.  (It works fine.)
Command:
```
bgpq4 -h whois.radb.net -S APNIC,RIPE,ARIN,AFRNIC,LANIC -A -J -z  -4 -m 24 AS-GEEKNET -l pl4-AS-GEEKNET
```
Output: (The filter should reject all IPv4 prefixes.)
```
policy-options {
replace:
  route-filter-list pl4-AS-GEEKNET {
    103.157.110.0/23 upto /24;
    103.159.176.0/23 upto /24;
  }
}
```

- Example 2: An AS-SET without route object. (Pure IPv6)

Command:
```
bgpq4 -h whois.radb.net -S APNIC,RIPE,ARIN,AFRNIC,LANIC -A -J -z  -4 -m 24 AS-GEEKNET-APAC -l pl4-AS-GEEKNET-APAC
```
Output: (The filter should reject all IPv4 prefixes.)
```
policy-options {
replace:
  route-filter-list pl4-AS-GEEKNET-APAC {
    route-filter 0.0.0.0/0 orlonger reject;
  }
}
```
However, I import the output to the router, and it returns a syntax error. After checking the Juniper KB, I confirmed there is a grammar error in the output function. It should output `0.0.0.0/0 orlonger reject;` rather than `route-filter 0.0.0.0/0 orlonger reject;`. 
The syntax definition of route-filter-list :
```
route-filter-list route-filter-list-name {
ip-addresses <exact | longer | orlonger | prefix-length-range | through | upto> label range start : end;
ip-addresses <exact | longer | orlonger | prefix-length-range | through | upto> label-allocation-fallback-reject;
ip-addresses exact label value;
ip-addresses exact label-allocation-fallback-reject;
```
Reference link: [Juniper KB](https://www.juniper.net/documentation/us/en/software/junos/routing-policy/topics/ref/statement/route-filter-list-edit-policy-options.html)

Finally, I locate the print function and correct it. And it works fine after correcting the syntax error.

AS-SET with route object test.
```
# bgpq4 -h whois.radb.net -S APNIC,RIPE,ARIN,AFRNIC,LANIC  -J -z  -4 -m 24 AS-GEEKNET -l pl4-AS-GEEKNET
policy-options {
replace:
  route-filter-list pl4-AS-GEEKNET {
    103.157.110.0/23 exact;
    103.157.110.0/24 exact;
    103.157.111.0/24 exact;
    103.159.176.0/23 exact;
    103.159.176.0/24 exact;
    103.159.177.0/24 exact;
  }
}
# bgpq4 -h whois.radb.net -S APNIC,RIPE,ARIN,AFRNIC,LANIC  -E -J  -4 -m 24 AS-GEEKNET -l pl4-AS-GEEKNET
policy-options {
 policy-statement pl4-AS-GEEKNET { 
replace:
  from {
    route-filter 103.157.110.0/23 exact;
    route-filter 103.157.110.0/24 exact;
    route-filter 103.157.111.0/24 exact;
    route-filter 103.159.176.0/23 exact;
    route-filter 103.159.176.0/24 exact;
    route-filter 103.159.177.0/24 exact;
  }
 }
}
```
AS-SET without route object test.
```
# bgpq4 -h whois.radb.net -S APNIC,RIPE,ARIN,AFRNIC,LANIC  -E -J  -4 -m 24 AS-GEEKNET-APAC -l pl4-AS-GEEKNET-APAC
policy-options {
 policy-statement pl4-AS-GEEKNET-APAC { 
replace:
  from {
    route-filter 0.0.0.0/0 orlonger reject;
  }
 }
}
# bgpq4 -h whois.radb.net -S APNIC,RIPE,ARIN,AFRNIC,LANIC  -z -J  -4 -m 24 AS-GEEKNET-APAC -l pl4-AS-GEEKNET-APAC
policy-options {
replace:
  route-filter-list pl4-AS-GEEKNET-APAC {
    0.0.0.0/0 orlonger reject;
  }
}
```