### PR TITLE
Huawei aspath bugfix

### DIFF
--- a/bgpq4_printer.c
+++ b/bgpq4_printer.c
@@ -528,7 +528,7 @@ bgpq4_print_huawei_aspath(FILE* f, struct bgpq_expander* b)
 	if (b->asn32s[b->asnumber / 65536] &&
 	    b->asn32s[b->asnumber / 65535][(b->asnumber % 65536) / 8] &
 	    (0x80 >> (b->asnumber % 8))) {
-		fprintf(f, "ip as-path-filter %s permit ^%u(%u)*$\n",
+		fprintf(f, "ip as-path-filter %s permit ^%u(_%u)*$\n",
 		    b->name ? b->name : "NN", b->asnumber, b->asnumber);
 		empty=0;
 	}
@@ -547,7 +547,7 @@ bgpq4_print_huawei_aspath(FILE* f, struct bgpq_expander* b)
 						continue;
 
 					if (!nc) {
-						fprintf(f, "ip as-path-filter %s permit ^%u([0-9]+)*"
+						fprintf(f, "ip as-path-filter %s permit ^%u(_[0-9]+)*"
 						    "_(%u",
 						    b->name ? b->name : "NN",
 						    b->asnumber,

--- a/bgpq4_printer.c
+++ b/bgpq4_printer.c
@@ -590,7 +590,7 @@ bgpq4_print_huawei_oaspath(FILE* f, struct bgpq_expander* b)
 	if (b->asn32s[b->asnumber / 65536] &&
 	     b->asn32s[b->asnumber / 65536][(b->asnumber % 65536) / 8] &
 	     (0x80 >> (b->asnumber % 8))) {
-		fprintf(f,"ip as-path-filter %s permit (_%u)*$\n",
+		fprintf(f,"ip as-path-filter %s permit ^(_%u)*$\n",
 		    b->name ? b->name : "NN", b->asnumber);
 		empty = 0;
 	}


### PR DESCRIPTION
Although I don't use as-path filters myself, the regular expression for huawei inbound as-path filter seems incorrect to me:

```
 ./bgpq4 -Uf 112 AS-SPACENET
undo ip as-path-filter NN
ip as-path-filter NN permit ^112(112)*$
ip as-path-filter NN permit ^112([0-9]+)*_(5539|8481|8763|8874|12136|21416|23600|24151)$
ip as-path-filter NN permit ^112([0-9]+)*_(25152|25354|31529|34906|35052|42385|44450|49488)$
ip as-path-filter NN permit ^112([0-9]+)*_(51966|197593|197997|204110|205973|208366|212467)$
```

The output should include `_` character: 

```
./bgpq4 -Uf 112 AS-SPACENET
undo ip as-path-filter NN
ip as-path-filter NN permit ^112(_112)*$
ip as-path-filter NN permit ^112(_[0-9]+)*_(5539|8481|8763|8874|12136|21416|23600|24151)$
ip as-path-filter NN permit ^112(_[0-9]+)*_(25152|25354|31529|34906|35052|42385|44450|49488)$
ip as-path-filter NN permit ^112(_[0-9]+)*_(51966|197593|197997|204110|205973|208366|212467)$
```

The first line from the outbound as-path filters looks incorrect too:

```
undo ip as-path-filter NN
ip as-path-filter NN permit (_112)*$
ip as-path-filter NN permit ^(_[0-9]+)*_(5539|8481|8763|8874|12136|21416|23600|24151)$
ip as-path-filter NN permit ^(_[0-9]+)*_(25152|25354|31529|34906|35052|42385|44450|49488)$
ip as-path-filter NN permit ^(_[0-9]+)*_(51966|197593|197997|204110|205973|208366|212467)$
```

This should be:

```
ip as-path-filter NN permit ^(_112)*$
```
