### PR TITLE
Huawei XPL format support

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,12 @@ The options are as follows:
 
 > generate config for Huawei devices (Cisco IOS by default)
 
+**-u**
+
+> generate output in Huawei XPL format.
+
+#### -W `length`
+
 **-X**
 
 > generate config for Cisco IOS XR devices (plain IOS by default).

--- a/README.md
+++ b/README.md
@@ -167,8 +167,6 @@ The options are as follows:
 
 > generate output in Huawei XPL format.
 
-#### -W `length`
-
 **-X**
 
 > generate config for Cisco IOS XR devices (plain IOS by default).

--- a/bgpq4.8
+++ b/bgpq4.8
@@ -124,6 +124,8 @@ disable pipelining (not recommended).
 generate as-path strings of no more than len items (use 0 for inifinity).
 .It Fl U
 generate config for Huawei devices (Cisco IOS by default)
+.It Fl u
+generate config for Huawei devices in XPL format (Cisco IOS by default)
 .It Fl X
 generate config for Cisco IOS XR devices (plain IOS by default).
 .It Fl z

--- a/extern.h
+++ b/extern.h
@@ -58,6 +58,7 @@ typedef enum {
 	V_FORMAT,
 	V_NOKIA,
 	V_HUAWEI,
+	V_HUAWEI_XPL,
 	V_MIKROTIK,
 	V_NOKIA_MD,
 	V_ARISTA

--- a/main.c
+++ b/main.c
@@ -59,6 +59,7 @@ usage(int ecode)
 	printf(" no option : Cisco IOS Classic (default)\n");
 	printf(" -X        : Cisco IOS XR\n");
 	printf(" -U        : Huawei\n");
+	printf(" -u        : Huawei XPL\n");
 	printf(" -j        : JSON\n");
 	printf(" -J        : Juniper Junos\n");
 	printf(" -K        : MikroTik RouterOS\n");
@@ -134,8 +135,8 @@ vendor_exclusive(void)
 {
 	fprintf(stderr, "-b (BIRD), -B (OpenBGPD), -F (formatted), -J (Junos),"
 	    " -j (JSON), -N (Nokia SR OS Classic), -n (Nokia SR OS MD-CLI),"
-	    " -U (Huawei), -e (Arista) and -X (IOS XR) options are mutually"
-	    " exclusive\n");
+	    " -U (Huawei), -u (Huawei XPL), -e (Arista) and -X (IOS XR) options "
+	    " are mutually exclusive\n");
 	exit(1);
 }
 

--- a/main.c
+++ b/main.c
@@ -198,7 +198,7 @@ main(int argc, char* argv[])
 		expander.sources=getenv("IRRD_SOURCES");
 
 	while ((c = getopt(argc, argv,
-	    "46a:AbBdDEeF:S:jJKf:l:L:m:M:NnW:pr:R:G:tTh:UwXsvz")) != EOF) {
+	    "46a:AbBdDEeF:S:jJKf:l:L:m:M:NnW:pr:R:G:tTh:UuwXsvz")) != EOF) {
 	switch (c) {
 	case '4':
 		/* do nothing, expander already configured for IPv4 */
@@ -402,6 +402,11 @@ main(int argc, char* argv[])
 		if (expander.vendor)
 			exclusive();
 		expander.vendor = V_HUAWEI;
+		break;
+	case 'u':
+		if (expander.vendor)
+			exclusive();
+		expander.vendor = V_HUAWEI_XPL;
 		break;
 	case 'W':
 		expander.aswidth = atoi(optarg);

--- a/printer.c
+++ b/printer.c
@@ -407,6 +407,62 @@ bgpq4_print_huawei_aspath(FILE *f, struct bgpq_expander *b)
 }
 
 static void
+bgpq4_print_huawei_xpl_aspath(FILE* f, struct bgpq_expander* b)
+{
+	int nc = 0, i, j, k, comma = 0;
+
+	fprintf(f, "xpl as-path-list %s", b->name ? b->name : "NN");
+
+	if (b->asn32s[b->asnumber / 65536] &&
+	    b->asn32s[b->asnumber / 65536][(b->asnumber % 65536) / 8] &
+	    (0x80 >> (b->asnumber%8))) {
+		fprintf(f,"\n  regular ^%u(_%u)*$", b->asnumber,
+		    b->asnumber);
+		comma = 1;
+	}
+
+	for (k = 0; k < 65536; k++) {
+
+		if (!b->asn32s[k])
+			continue;
+
+		for (i = 0; i < 8192; i++) {
+			for (j = 0; j < 8; j++) {
+				if (b->asn32s[k][i] & (0x80 >> j)) {
+
+					if (k * 65536 + i * 8 + j == b->asnumber)
+						continue;
+
+					if (!nc) {
+						fprintf(f, "%s\n  regular ^%u(_[0-9]+)*_(%u",
+						    comma ? "," : "",
+						    b->asnumber,
+						    k * 65536 + i * 8 + j);
+						comma=1;
+					} else {
+						fprintf(f, "|%u",
+						    k * 65536 + i * 8 + j);
+					}
+
+					nc++;
+
+					if (nc == b->aswidth) {
+						fprintf(f, ")$");
+						nc = 0;
+					}
+				}
+			}
+		}
+	}
+
+	if (nc)
+		fprintf(f, ")$");
+
+	fprintf(f, "\nend-list\n");
+	return 0;
+}
+
+static void
 bgpq4_print_huawei_oaspath(FILE *f, struct bgpq_expander *b)
 {
 	int			 nc = 0;
@@ -443,6 +499,60 @@ bgpq4_print_huawei_oaspath(FILE *f, struct bgpq_expander *b)
 
 	if (nc)
 		fprintf(f, ")$\n");
+}
+
+static void
+bgpq4_print_huawei_xpl_oaspath(FILE* f, struct bgpq_expander* b)
+{
+	int nc = 0, i, j, k, comma = 0;
+
+	fprintf(f, "xpl as-path-list %s", b->name ? b->name : "NN");
+
+	if (b->asn32s[b->asnumber / 65536] &&
+	    b->asn32s[b->asnumber / 65536][(b->asnumber % 65536) / 8] &
+	    (0x80 >> (b->asnumber % 8))) {
+		fprintf(f,"\n  regular ^(_%u)*$", b->asnumber);
+		comma = 1;
+	}
+
+	for (k = 0; k < 65536; k++) {
+
+		if (!b->asn32s[k])
+			continue;
+
+		for (i = 0; i < 8192; i++) {
+			for (j = 0; j < 8; j++) {
+
+				if (b->asn32s[k][i] & (0x80 >> j)) {
+
+					if (k * 65536 + i * 8 + j == b->asnumber)
+						continue;
+
+					if (!nc) {
+						fprintf(f,"%s\n  regular ^(_[0-9]+)*_(%u",
+						    comma ? "," : "",
+						    k * 65536 + i * 8 + j);
+						comma = 1;
+					} else {
+						fprintf(f,"|%u",k*65536+i*8+j);
+					}
+
+					nc++;
+					if (nc == b->aswidth) {
+						fprintf(f,")$");
+						nc=0;
+					}
+				}
+			}
+		}
+	}
+
+	if (nc)
+		fprintf(f,")$");
+
+	fprintf(f,"\nend-list\n");
+
+	return 0;
 }
 
 static void
@@ -763,6 +873,9 @@ bgpq4_print_aspath(FILE *f, struct bgpq_expander *b)
 	case V_HUAWEI:
 		bgpq4_print_huawei_aspath(f, b);
 		break;
+	case V_HUAWEI_XPL:
+		bgpq4_print_huawei_xpl_aspath(f, b);
+		break;
 	default:
 		sx_report(SX_FATAL,"Unknown vendor %i\n", b->vendor);
 	}
@@ -793,6 +906,9 @@ bgpq4_print_oaspath(FILE *f, struct bgpq_expander *b)
 		break;
 	case V_HUAWEI:
 		bgpq4_print_huawei_oaspath(f, b);
+		break;
+	case V_HUAWEI_XPL:
+		bgpq4_print_huawei_xpl_oaspath(f, b);
 		break;
 	default:
 		sx_report(SX_FATAL,"Unknown vendor %i\n", b->vendor);
@@ -971,6 +1087,43 @@ bgpq4_print_hprefix(struct sx_radix_node *n, void *ff)
 checkSon:
 	if (n->son)
 		bgpq4_print_hprefix(n->son, ff);
+}
+
+static void
+bgpq4_print_hprefixxpl(struct sx_radix_node* n, void* ff)
+{
+	char prefix[128];
+	FILE* f = (FILE*)ff;
+
+	if (!f)
+		f = stdout;
+
+	if (n->isGlue)
+		goto checkSon;
+
+	sx_prefix_snprintf_sep(n->prefix, prefix, sizeof(prefix), " ");
+
+	if (n->isAggregate) {
+		if (n->aggregateLow>n->prefix->masklen) {
+			fprintf(f,"%s %s ge %u le %u",
+			    needscomma ? ",\n " : " ",
+			    prefix, n->aggregateLow, n->aggregateHi);
+		} else {
+			fprintf(f,"%s %s le %u",
+			    needscomma ? ",\n " : " ",
+			    prefix, n->aggregateHi);
+		}
+	} else {
+		fprintf(f, "%s %s",
+		    needscomma ? ",\n " : " ",
+		    prefix);
+	}
+
+	needscomma = 1;
+
+checkSon:
+	if (n->son)
+		bgpq4_print_hprefixxpl(n->son, ff);
 }
 
 static void
@@ -1370,6 +1523,20 @@ bgpq4_print_huawei_prefixlist(FILE *f, struct bgpq_expander *b)
 }
 
 static void
+bgpq4_print_huawei_xpl_prefixlist(FILE* f, struct bgpq_expander* b)
+{
+	bname = b->name ? b->name : "NN";
+
+	fprintf(f, "no xpl %s-prefix-list %s\nxpl %s-prefix-list %s\n", b->family==AF_INET ? "ip" : "ipv6", bname, b->family==AF_INET ? "ip" : "ipv6", bname);
+
+	sx_radix_tree_foreach(b->tree, bgpq4_print_hprefixxpl, f);
+
+	fprintf(f, "\nend-list\n");
+
+	return 0;
+}
+
+static void
 bgpq4_print_arista_prefixlist(FILE *f, struct bgpq_expander *b)
 {
 	bname = b->name ? b->name : "NN";
@@ -1614,6 +1781,9 @@ bgpq4_print_prefixlist(FILE *f, struct bgpq_expander *b)
 		break;
 	case V_HUAWEI:
 		bgpq4_print_huawei_prefixlist(f, b);
+		break;
+	case V_HUAWEI_XPL:
+		bgpq4_print_huawei_xpl_prefixlist(f, b);
 		break;
 	case V_MIKROTIK:
 		bgpq4_print_mikrotik_prefixlist(f, b);


### PR DESCRIPTION
Support for Huawei extended routing-policy language (XPL) format for ip-prefix list and as-path.  I do not use as-path filters myself, so this part should be taken with a grain of salt. I chosen `-u` for Huawei XPL format. 
