### PR TITLE
compat: don't build when strlcpy is present

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,4 +1,4 @@
-SUBDIRS = include compat
+SUBDIRS = include
 ACLOCAL_AMFLAGS = -I m4
 
 AM_CPPFLAGS = -I$(top_srcdir)/include
@@ -10,7 +10,11 @@ bin_PROGRAMS=bgpq4
 dist_man8_MANS=bgpq4.8
 
 bgpq4_LDADD = $(PLATFORM_LDADD) $(PROG_LDADD)
+
+if !HAVE_STRLCPY
+SUBDIRS += compat
 bgpq4_LDADD += $(top_builddir)/compat/libcompat.la
+endif
 
 bgpq4_SOURCES=main.c extern.h printer.c expander.c \
     sx_maxsockbuf.c \

--- a/compat/Makefile.am
+++ b/compat/Makefile.am
@@ -2,9 +2,6 @@ AM_CPPFLAGS = -I$(top_srcdir)/include
 
 noinst_LTLIBRARIES = libcompat.la
 
-libcompat_la_SOURCES =
 libcompat_la_LIBADD = $(PLATFORM_LDADD)
 
-if !HAVE_STRLCPY
-libcompat_la_SOURCES += strlcpy.c
-endif
+libcompat_la_SOURCES = strlcpy.c


### PR DESCRIPTION
In environments where `strlcpy` is present, an attempt will be made to build `libcompat.la`, but `libcompat` will have no sources because of the conditional in `compat/Makefile.am`. As such the build will fail because `ar` is trying to create an archive without any sources passed to it.

Instead, move the conditional check to the top-level `Makefile.am`, such that `strlcpy.lo` is not built and also `libcompat.la` is ignored entirely.