### PR TITLE
Add AS-List Feature for JunOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 \[**-f**&nbsp;*asn*&nbsp;|
 **-F**&nbsp;*fmt*&nbsp;|
 **-G**&nbsp;*asn*
+**-H**&nbsp;*asn*
 **-t**]
 \[**-46ABbDdJjNnsXU**]
 \[**-a**&nbsp;*asn*]
@@ -81,6 +82,10 @@ The options are as follows:
 **-G** *number*
 
 > generate output as-path access-list.
+
+**-H** *number*
+
+> generate output as-list for JunOS 21.3R1+ `as-path-origin` filter (JunOS only)
 
 **-h** *host\[:port]*
 

--- a/extern.h
+++ b/extern.h
@@ -68,6 +68,7 @@ typedef enum {
 	T_NONE = 0,
 	T_ASPATH,
 	T_OASPATH,
+	T_ASLIST,
 	T_ASSET,
 	T_PREFIXLIST,	
 	T_EACL,
@@ -132,6 +133,7 @@ void bgpq4_print_eacl(FILE *f, struct bgpq_expander *b);
 void bgpq4_print_aspath(FILE *f, struct bgpq_expander *b);
 void bgpq4_print_asset(FILE *f, struct bgpq_expander *b);
 void bgpq4_print_oaspath(FILE *f, struct bgpq_expander *b);
+void bgpq4_print_aslist(FILE *f, struct bgpq_expander *b);
 void bgpq4_print_route_filter_list(FILE *f, struct bgpq_expander *b);
 
 void sx_radix_node_freeall(struct sx_radix_node *n);


### PR DESCRIPTION
A proposal to implement issue #56 `Junos: AS-Path filtering without regex `.

I didn't know which letter to pick for the option, so I randomly chose `-H`. If you have a better idea, let me know.
It's the most simple approach to implement this: It just generates the as-list-group for origin-match.
It behaves the same as the as-path generator: a0 is the neighbor ASN, the following lists are the origin ASNs computed from the AS-set.
The amount of ASNs per line can be set using the `-W` option.

Example Output:
```
# /nix/store/lzsjz51mm9mcdwflapcyzd79i0kdn09f-bgpq4-1.2/bin/bgpq4 AS-WOBCOM -J -H 9136 -W 10 -l AS9136_IN
policy-options {
replace:
 as-list-group AS9136_IN {
  as-list a0 members 9136;
  as-list a1 members [ 112 248 250 3573 3624 6766 12654 12748 13020 13130 ];
  as-list a2 members [ 20488 21158 24956 29670 31451 34219 39225 39788 44194 48387 ];
  as-list a3 members [ 48777 49009 49745 49933 50017 50472 59645 60729 64404 64475 ];
  as-list a4 members [ 132362 200490 201173 201701 202329 204675 204911 205597 206236 206313 ];
  as-list a5 members [ 206356 206554 206618 206740 206813 206946 207180 207871 208135 208294 ];
  as-list a6 members [ 208395 208633 208727 208772 208893 208942 209347 209530 209894 210916 ];
  as-list a7 members [ 211479 212520 212989 213027 213106 213341 396507 ];
 }
}
```

Please give feedback! This is just my proposal, I'm willing to implement things in a different fashion.