### PR TITLE
Remove non-existing -P option from documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,10 +132,6 @@ It's options are as follows:
 
 > accept routes registered for private ASNs (default: disabled)
 
-**-P**
-
-> generate prefix-list (default, backward compatibility).
-
 **-r** *len*
 
 > allow more specific routes starting with specified masklen too.

--- a/bgpq4.8
+++ b/bgpq4.8
@@ -111,8 +111,6 @@ generate config for Nokia SR OS MD-CLI (Cisco IOS by default)
 generate config for Nokia SR OS classic CLI (Cisco IOS by default).
 .It Fl p
 accept routes registered for private ASNs (default: disabled)
-.It Fl P
-generate prefix-list (default, backward compatibility).
 .It Fl r Ar len
 allow more specific routes starting with specified masklen too.
 .It Fl R Ar len


### PR DESCRIPTION
While this doesn't fix #68 alone, it removes `-P` option from documentation to match the actual source code.