### PR TITLE
Use to GitHub actions/checkout@v3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: bootstrap
       run: ./bootstrap
     - name: configure

--- a/.github/workflows/matrixbuild.yml
+++ b/.github/workflows/matrixbuild.yml
@@ -26,6 +26,6 @@ jobs:
           - alpine:edge
           - alpine:3.16
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Run build on ${{matrix.dockerenv}}
       run: docker build . --file .github/images/${{matrix.dockerenv}}.Dockerfile --build-arg image=${{matrix.dockerenv}}


### PR DESCRIPTION
Current usage of GitHub `actions/checkout@v1` should throw deprecation warnings…