### PR TITLE
Add CodeQL analysis

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,38 @@
+name: CodeQL analysis
+
+on:
+  push:
+  pull_request:
+  schedule:
+    # build the main branch every Tuesday morning
+    - cron: '15 6 * * 2'
+  workflow_dispatch:
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'cpp' ]
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v2
+      with:
+        languages: ${{ matrix.language }}
+    - name: Build Application using script
+      run: |
+        ./bootstrap
+        ./configure
+        make
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v2
+      with:
+        category: "/language:${{matrix.language}}"


### PR DESCRIPTION
LGTM.com will be shut down in December 2022 and recommend to use GitHub code scanning instead.

See also: https://github.blog/2022-08-15-the-next-step-for-lgtm-com-github-code-scanning/