### PR TITLE
Add support for Nokia SR Linux IP prefix lists / ACL filters

### DIFF
--- a/bgpq4.8
+++ b/bgpq4.8
@@ -109,6 +109,8 @@ maximum prefix-length of accepted prefixes (default: 32 for IPv4 and
 extra match conditions for Juniper route-filters.
 .It Fl n
 generate config for Nokia SR OS MD-CLI (Cisco IOS by default)
+.It Fl n2
+generate config for Nokia SR Linux (Cisco IOS by default)
 .It Fl N
 generate config for Nokia SR OS classic CLI (Cisco IOS by default).
 .It Fl p

--- a/extern.h
+++ b/extern.h
@@ -62,7 +62,8 @@ typedef enum {
 	V_MIKROTIK6,
 	V_MIKROTIK7,
 	V_NOKIA_MD,
-	V_ARISTA
+	V_ARISTA,
+	V_NOKIA_SRL,
 } bgpq_vendor_t;
 
 typedef enum {

--- a/main.c
+++ b/main.c
@@ -199,8 +199,15 @@ main(int argc, char* argv[])
 		expander.sources=getenv("IRRD_SOURCES");
 
 	while ((c = getopt(argc, argv,
-	    "3467a:AbBdDEeF:S:jJKf:l:L:m:M:NnpW:r:R:G:H:tTh:UuwXsvz")) != EOF) {
+	    "23467a:AbBdDEeF:S:jJKf:l:L:m:M:NnpW:r:R:G:H:tTh:UuwXsvz")) != EOF) {
 	switch (c) {
+	case '2':
+		if (expander.vendor != V_NOKIA_MD) {
+			sx_report(SX_FATAL, "'2' can only be used after -n\n");
+			exit(1);
+		}
+		expander.vendor = V_NOKIA_SRL;
+		break;
 	case '3':
 		/* do nothing, 32-bit ASN support is assumed */
 		break;
@@ -473,6 +480,7 @@ main(int argc, char* argv[])
 			case V_JUNIPER:
 			case V_NOKIA:
 			case V_NOKIA_MD:
+			case V_NOKIA_SRL:
 				expander.aswidth = 8;
 				break;
 			case V_BIRD:
@@ -492,6 +500,7 @@ main(int argc, char* argv[])
 			case V_JUNIPER:
 			case V_NOKIA:
 			case V_NOKIA_MD:
+			case V_NOKIA_SRL:
 				expander.aswidth = 8;
 				break;
 			}
@@ -564,7 +573,7 @@ main(int argc, char* argv[])
 	}
 
 	if (aggregate
-	    && (expander.vendor == V_NOKIA_MD || expander.vendor == V_NOKIA)
+	    && (expander.vendor == V_NOKIA_MD || expander.vendor == V_NOKIA || expander.vendor == V_NOKIA_SRL)
 	    && expander.generation != T_PREFIXLIST) {
 		sx_report(SX_FATAL, "Sorry, aggregation (-A) is not supported with "
 		    "ip-prefix-lists (-E) on Nokia.\n");
@@ -572,7 +581,7 @@ main(int argc, char* argv[])
 	}
 
 	if (refine
-	    && (expander.vendor == V_NOKIA_MD || expander.vendor == V_NOKIA)
+	    && (expander.vendor == V_NOKIA_MD || expander.vendor == V_NOKIA || expander.vendor == V_NOKIA_SRL)
 	    && expander.generation != T_PREFIXLIST) {
 		sx_report(SX_FATAL, "Sorry, more-specifics (-R) is not supported with "
 		    "ip-prefix-lists (-E) on Nokia.\n");
@@ -580,7 +589,7 @@ main(int argc, char* argv[])
 	}
 
 	if (refineLow
-	     && (expander.vendor == V_NOKIA_MD || expander.vendor == V_NOKIA)
+	     && (expander.vendor == V_NOKIA_MD || expander.vendor == V_NOKIA || expander.vendor == V_NOKIA_SRL)
 	     && expander.generation != T_PREFIXLIST) {
 		sx_report(SX_FATAL, "Sorry, more-specifics (-r) is not supported with "
 		    "ip-prefix-lists (-E) on Nokia.\n");

--- a/printer.c
+++ b/printer.c
@@ -40,6 +40,13 @@
 
 extern int debug_expander;
 
+#define max(a,b)             \
+({                           \
+    __typeof__ (a) _a = (a); \
+    __typeof__ (b) _b = (b); \
+    _a > _b ? _a : _b;       \
+})
+
 static void 
 bgpq4_print_cisco_aspath(FILE *f, struct bgpq_expander *b)
 {
@@ -1371,6 +1378,32 @@ checkSon:
 }
 
 static void
+bgpq4_print_nokia_srl_prefix(struct sx_radix_node *n, void *ff)
+{
+	char 	 prefix[128];
+	FILE	*f = (FILE*)ff;
+
+	if (n->isGlue)
+		goto checkSon;
+
+	if (!f)
+		f = stdout;
+
+	sx_prefix_snprintf(n->prefix, prefix, sizeof(prefix));
+
+	if (!n->isAggregate) {
+		fprintf(f, "    prefix %s mask-length-range exact { }\n", prefix);
+	} else {
+		fprintf(f, "    prefix %s mask-length-range %u..%u { }\n",  prefix, 
+		  max(n->aggregateLow,n->prefix->masklen), n->aggregateHi);
+	}
+
+checkSon:
+	if (n->son)
+		bgpq4_print_nokia_srl_prefix(n->son, ff);
+}
+
+static void
 bgpq4_print_juniper_prefixlist(FILE *f, struct bgpq_expander *b)
 {
 	fprintf(f, "policy-options {\nreplace:\n prefix-list %s {\n",
@@ -1717,6 +1750,24 @@ bgpq4_print_nokia_md_ipprefixlist(FILE *f, struct bgpq_expander *b)
 }
 
 static void
+bgpq4_print_nokia_srl_prefixset(FILE *f, struct bgpq_expander *b)
+{
+	bname = b->name ? b->name : "NN";
+
+	fprintf(f, "/routing-policy\ndelete prefix-set \"%s\"\n",
+	    bname);
+
+	fprintf(f, "prefix-set \"%s\" {\n", bname);
+
+	if (!sx_radix_tree_empty(b->tree)) {
+		sx_radix_tree_foreach(b->tree, bgpq4_print_nokia_srl_prefix, f);
+	}
+
+	fprintf(f,"}\n");
+}
+
+
+static void
 bgpq4_print_k6prefix(struct sx_radix_node *n, void *ff)
 {
 	char	 prefix[128];
@@ -1827,6 +1878,9 @@ bgpq4_print_prefixlist(FILE *f, struct bgpq_expander *b)
 	case V_NOKIA_MD:
 		bgpq4_print_nokia_md_ipprefixlist(f, b);
 		break;
+	case V_NOKIA_SRL:
+		bgpq4_print_nokia_srl_prefixset(f, b);
+		break;
 	case V_HUAWEI:
 		bgpq4_print_huawei_prefixlist(f, b);
 		break;
@@ -1862,6 +1916,9 @@ bgpq4_print_eacl(FILE *f, struct bgpq_expander *b)
 		break;
 	case V_NOKIA_MD:
 		bgpq4_print_nokia_md_prefixlist(f, b);
+		break;
+	case V_NOKIA_SRL:
+		bgpq4_print_nokia_srl_prefixset(f, b);
 		break;
 	default:
 		sx_report(SX_FATAL, "unreachable point\n");

--- a/printer.c
+++ b/printer.c
@@ -1394,7 +1394,7 @@ bgpq4_print_nokia_srl_prefix(struct sx_radix_node *n, void *ff)
 	if (!n->isAggregate) {
 		fprintf(f, "    prefix %s mask-length-range exact { }\n", prefix);
 	} else {
-		fprintf(f, "    prefix %s mask-length-range %u..%u { }\n",  prefix, 
+		fprintf(f, "    prefix %s mask-length-range %u..%u { }\n", prefix, 
 		  max(n->aggregateLow,n->prefix->masklen), n->aggregateHi);
 	}
 

--- a/tests/generate_outputs.sh
+++ b/tests/generate_outputs.sh
@@ -45,6 +45,7 @@ fi
 "${BGPQ4_PATH}" -4 -K7 "AS${TEST_ASN}" > "${OUT_DIR}/routeros7--4.txt"
 "${BGPQ4_PATH}" -4 -N "AS${TEST_ASN}" > "${OUT_DIR}/sros--4.txt"
 "${BGPQ4_PATH}" -4 -n "AS${TEST_ASN}" > "${OUT_DIR}/sros-mdcli--4.txt"
+"${BGPQ4_PATH}" -4 -n2 "AS${TEST_ASN}" > "${OUT_DIR}/srlinux--4.txt"
 
 # Test the IPv6 prefix-list output formatting for each supported NOS:
 "${BGPQ4_PATH}" -6 -b "AS${TEST_ASN}" > "${OUT_DIR}/bird--6.txt"
@@ -61,6 +62,7 @@ fi
 "${BGPQ4_PATH}" -6 -K7 "AS${TEST_ASN}" > "${OUT_DIR}/routeros7--6.txt"
 "${BGPQ4_PATH}" -6 -N "AS${TEST_ASN}" > "${OUT_DIR}/sros--6.txt"
 "${BGPQ4_PATH}" -6 -n "AS${TEST_ASN}" > "${OUT_DIR}/sros-mdcli--6.txt"
+"${BGPQ4_PATH}" -6 -n2 "AS${TEST_ASN}" > "${OUT_DIR}/srlinux--6.txt"
 
 # Test the AS path list output formatting for each supported NOS:
 "${BGPQ4_PATH}" "${TEST_AS_SET}" -f "${TEST_ASN}" -b > "${OUT_DIR}/bird--asp.txt"

--- a/tests/reference/srlinux--4.txt
+++ b/tests/reference/srlinux--4.txt
@@ -1,0 +1,6 @@
+/routing-policy
+delete prefix-set "NN"
+prefix-set "NN" {
+    prefix 192.31.196.0/24 mask-length-range exact { }
+    prefix 192.175.48.0/24 mask-length-range exact { }
+}

--- a/tests/reference/srlinux--6.txt
+++ b/tests/reference/srlinux--6.txt
@@ -1,0 +1,6 @@
+/routing-policy
+delete prefix-set "NN"
+prefix-set "NN" {
+    prefix 2001:4:112::/48 mask-length-range exact { }
+    prefix 2620:4f:8000::/48 mask-length-range exact { }
+}


### PR DESCRIPTION
* Using '-n2' flag
* supports both bgp prefix lists and acl ip prefix filters
* Updated tests (note that -E isn't covered by any tests, for any platform)

Sample:
```
jeroen@jvb-vm:~/srlinux/bgpq4$ ./bgpq4 -n2 AS37271:RS-EXAMPLE
/routing-policy
delete prefix-set "NN"
prefix-set "NN" {
    prefix 192.0.2.0/27 mask-length-range exact { }
    prefix 192.0.2.32/27 mask-length-range exact { }
   # ... etc (cut)
}
jeroen@jvb-vm:~/srlinux/bgpq4$ ./bgpq4 -En2 AS37271:RS-EXAMPLE
/acl 
delete ipv4-filter "NN"
ipv4-filter "NN" {
 entry 10 {
  action { accept { } }
  match { source-ip { prefix 192.0.2.0/27 } } }
 entry 20 {
  action { accept { } }
  match { source-ip { prefix 192.0.2.32/27 } } }

 # ...etc (cut)
}
```