### PR TITLE
Added container build workflow

### DIFF
--- a/.github/images/alpine:3.Dockerfile
+++ b/.github/images/alpine:3.Dockerfile
@@ -1,0 +1,24 @@
+# to build the image locally tagged with the short commit hash:
+# docker build -t bgpq4:$(git rev-parse --short HEAD) -f .github/images/alpine:3.Dockerfile .
+ARG IMAGE=alpine:3
+FROM $IMAGE as builder
+
+# Install dependencies
+RUN apk upgrade
+RUN apk add autoconf automake file gcc gzip libtool make musl-dev
+
+# Add source code
+ADD . /src
+WORKDIR /src
+
+# Run steps
+RUN ./bootstrap
+RUN ./configure
+RUN make
+RUN make check
+RUN make distcheck
+
+FROM alpine:3
+COPY --from=builder /src/bgpq4 /bgp/
+WORKDIR /bgp
+ENTRYPOINT [ "./bgpq4" ]

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -1,0 +1,68 @@
+name: Container build
+"on":
+  push:
+    tags:
+      - "*" # Push events to any tag
+    branches:
+      - "main"
+
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Container tag to use for the build"
+        required: true
+        default: "test"
+
+jobs:
+  test:
+    uses: ./.github/workflows/unit-tests.yml
+
+  build:
+    name: Build container
+    runs-on: ubuntu-22.04
+    needs: test
+
+    steps:
+      - name: Set env vars
+        run: |
+          echo "CNT_TAG=${{ inputs.tag }}" >> $GITHUB_ENV
+
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - # Add support for more platforms with QEMU
+        # https://github.com/docker/setup-qemu-action
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/bgpq4
+          tags: |
+            # pick up tag provided from workflow_dispatch user's input
+            type=raw,value=${{ inputs.tag }}
+            type=ref,event=tag
+            type=ref,event=branch
+            # git short commit
+            type=sha
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          file: .github/images/alpine:3.Dockerfile
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -23,10 +23,6 @@ jobs:
     needs: test
 
     steps:
-      - name: Set env vars
-        run: |
-          echo "CNT_TAG=${{ inputs.tag }}" >> $GITHUB_ENV
-
       - name: Checkout
         uses: actions/checkout@v3
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -8,6 +8,7 @@ on:
       - reopened
       - ready_for_review
       - synchronize
+  workflow_call:
 
 jobs:
   output-unit-tests:

--- a/README.md
+++ b/README.md
@@ -447,6 +447,31 @@ Linux can be tuned in the following way:
 
 	sysctl -w net.ipv4.tcp_wmem="4096 65536 2097152"
 
+# CONTAINER IMAGE
+
+A multi-arch (linux/amd64 and linux/arm64) container image is built automatically for all tagged releases and `main` branch. The image is based on Alpine Linux and is available on [GitHub Container Registry](https://github.com/bgp/bgpq4/pkgs/container/bgpq4).
+
+Using the image is as simple as:
+
+	```
+	docker run --rm ghcr.io/bgp/bgpq4:latest -Jl eltel AS20597
+	policy-options {
+		replace:
+		prefix-list eltel {
+			81.9.0.0/20;
+			81.9.32.0/20;
+			81.9.96.0/20;
+			81.222.128.0/20;
+			81.222.160.0/20;
+			81.222.192.0/18;
+			85.249.8.0/21;
+			85.249.224.0/19;
+			89.112.0.0/17;
+			217.170.64.0/19;
+		}
+		}
+	```
+
 # BUILDING
 
 This project uses autotools. If you are building from the repository,


### PR DESCRIPTION
Hi @job 

I wanted to propose adding a workflow that builds an official multi-arch (amd64 and arm64) bgpq4 container image based on Alpine Linux.

bgpq4 container image boosts adoption as it is extremely easy to start using the tool on any system with container runtime, as well as it is the default packaging format for CI tools.

This PR contains the following:

1. A Dockerfile with multistage build process that minified the resulting image size down to 7MB.
2. A workflow `build-container` that implements the build and tagging process (more on it later)
3. An addition `on` action to existing `unit-tests.yml` workflow to make it callable from other workflows that depend on test step.
4. Doc entry to demonstrate the usage.

## Container build workflow

The Container build workflow uses official docker actions to generate tags and build-push actions.
The workflow is executed on each push to `main` and each `tag` event.

In addition to the automated workflow triggers, a manual trigger is added with a user input field. This may be useful when we want to build a container for a PR branch to test.

The following tags are automatically created (if not empty):

* `main` - points to latest commit on main branch
* `latest` - points to latest tagged commit
* `sha-xxxx` - points to commit hash on `main`
* `x.x.x` - tag version

Note, that for workflow to be able to push the image to the registry, the following permission needs to be added in the Security setting of the repo:

<img width="1211" alt="image" src="https://github.com/bgp/bgpq4/assets/5679861/f5fc329d-009a-4522-8610-2c30b44b78f9">
