### PR TITLE
Add feature to generate IP filters with statistics to count traffic to/from given AS, based on prefix list matches

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ It's options are as follows:
 
 > generate output in BIRD format (default: Cisco).
 
+**-c**
+
+> generate IP prefix ingress/egress filters for counting traffic, based on dst/src IP matches to a per-AS prefix list (Nokia MD-CLI only)
+
 **-d**
 
 > enable some debugging output.

--- a/extern.h
+++ b/extern.h
@@ -74,7 +74,8 @@ typedef enum {
 	T_ASSET,
 	T_PREFIXLIST,	
 	T_EACL,
-	T_ROUTE_FILTER_LIST
+	T_ROUTE_FILTER_LIST,
+	T_TRAFFIC_COUNTING_FILTER,
 } bgpq_gen_t;
 
 struct bgpq_expander;
@@ -143,6 +144,7 @@ void bgpq4_print_asset(FILE *f, struct bgpq_expander *b);
 void bgpq4_print_oaspath(FILE *f, struct bgpq_expander *b);
 void bgpq4_print_aslist(FILE *f, struct bgpq_expander *b);
 void bgpq4_print_route_filter_list(FILE *f, struct bgpq_expander *b);
+void bgpq4_print_counting_filter(FILE *f, struct bgpq_expander *b);
 
 void sx_radix_node_freeall(struct sx_radix_node *n);
 void sx_radix_tree_freeall(struct sx_radix_tree *t);

--- a/main.c
+++ b/main.c
@@ -99,6 +99,7 @@ usage(int ecode)
 	printf(" -t        : generate as-sets for OpenBGPD (OpenBGPD 6.4+), BIRD "
 		"and JSON formats\n");
 	printf(" -z        : generate route-filter-list (Junos only)\n");
+	printf(" -c        : generate counting IP filters for ingress/egress (Nokia only)\n");
 	printf(" -W len    : specify max-entries on as-path/as-list line (use 0 for "
 		"infinity)\n");
 
@@ -199,7 +200,7 @@ main(int argc, char* argv[])
 		expander.sources=getenv("IRRD_SOURCES");
 
 	while ((c = getopt(argc, argv,
-	    "23467a:AbBdDEeF:S:jJKf:l:L:m:M:NnpW:r:R:G:H:tTh:UuwXsvz")) != EOF) {
+	    "23467a:AbBcdDEeF:S:jJKf:l:L:m:M:NnpW:r:R:G:H:tTh:UuwXsvz")) != EOF) {
 	switch (c) {
 	case '2':
 		if (expander.vendor != V_NOKIA_MD) {
@@ -254,6 +255,11 @@ main(int argc, char* argv[])
 		if (expander.vendor)
 			vendor_exclusive();
 		expander.vendor = V_OPENBGPD;
+		break;
+	case 'c':
+		if (expander.generation)
+			exclusive();
+		expander.generation = T_TRAFFIC_COUNTING_FILTER;
 		break;
 	case 'd':
 		debug_expander++;
@@ -310,7 +316,7 @@ main(int argc, char* argv[])
 		break;
 	case 'j':
 		if (expander.vendor)
-			vendor_exclusive();
+			vendor_exclusive(); 
 		expander.vendor = V_JSON;
 		break;
 	case 'K':
@@ -556,6 +562,11 @@ main(int argc, char* argv[])
 		sx_report(SX_FATAL, "Route-filter-lists (-z) supported for Juniper (-J)"
 		    " output only\n");
 
+	if (expander.generation == T_TRAFFIC_COUNTING_FILTER
+	    && expander.vendor != V_NOKIA_MD)
+		sx_report(SX_FATAL, "Packet counting IP ingress/egress filters based on "
+		    "prefix lists (-c) supported for Nokia MD (-n) output only\n");
+
 	if (expander.generation == T_ASSET
 	    && expander.vendor != V_JSON
 	    && expander.vendor != V_OPENBGPD
@@ -798,6 +809,9 @@ main(int argc, char* argv[])
 			break;
 		case T_ROUTE_FILTER_LIST:
 			bgpq4_print_route_filter_list(stdout, &expander);
+			break;
+		case T_TRAFFIC_COUNTING_FILTER:
+			bgpq4_print_counting_filter(stdout, &expander);
 			break;
 	}
 

--- a/printer.c
+++ b/printer.c
@@ -1374,7 +1374,6 @@ bgpq4_print_nokia_md_prefix(struct sx_radix_node *n, void *ff)
 checkSon:
 	if (n->son)
 		bgpq4_print_nokia_md_prefix(n->son, ff);
-
 }
 
 static void
@@ -1761,6 +1760,42 @@ bgpq4_print_nokia_md_prefixlist(FILE *f, struct bgpq_expander *b)
 }
 
 static void
+bgpq4_print_nokia_md_counting_filter(FILE *f, struct bgpq_expander *b)
+{
+	bname = b->name ? b->name : "NN";
+
+	// Generate prefix list for all prefixes in each AS
+	struct asn_entry	*asne;
+	char asbuf[16];
+
+	RB_FOREACH(asne, asn_tree, &b->asnlist) {
+
+		uint32_t entry = max( asne->asn % 2097152, (uint32_t)1); // entry based on AS, max 2097151
+
+		sprintf(asbuf, "AS%u", entry);
+		b->name = asbuf;
+		bgpq4_print_nokia_md_prefixlist(f,b);
+
+		// Enable auto-id for filters
+		fprintf(f,"/configure filter md-auto-id { filter-id-range { start 1 end 65535 } }\n");
+
+		// Add an entry to match the prefix list to the named IP filters for ingress/egress based on dst/src IP
+		for (int i=0; i<2; ++i) {
+		  fprintf(f,"/configure filter delete %s-filter \"%s-%s\"\n",
+		      b->tree->family == AF_INET ? "ip" : "ipv6", bname, i==0 ? "in" : "out");
+		  fprintf(f,"/configure filter %s-filter \"%s-%s\" {\n",
+		      b->tree->family == AF_INET ? "ip" : "ipv6", bname, i==0 ? "in" : "out");
+		  fprintf(f,"default-action accept\n");
+		  // Note: could add a port number or list of ports to match (say) only web traffic, DNS, etc.
+		  fprintf(f,"entry %u { match { %s-ip { ip-prefix-list \"%s\" } }\naction accept }\n", 
+		      entry, i==0 ? "src" : "dst", asbuf );
+
+		  fprintf(f,"}\n");
+		}
+	}
+}
+
+static void
 bgpq4_print_nokia_md_ipprefixlist(FILE *f, struct bgpq_expander *b)
 {
 	bname = b->name ? b->name : "NN";
@@ -1997,6 +2032,25 @@ bgpq4_print_route_filter_list(FILE *f, struct bgpq_expander *b)
 	switch(b->vendor) {
 	case V_JUNIPER:
 		bgpq4_print_juniper_route_filter_list(f, b);
+		break;
+	default:
+		sx_report(SX_FATAL, "unreachable point\n");
+	}
+}
+
+/*
+ * Creates IP ingress/egress filters each with an entry to match all prefixes
+ * for the given AS. This can be used to collect fine grained statistics about
+ * peering traffic ( i.e. how many packets/bytes are sent to/received from a given AS)
+ * 
+ * Entries for different AS are not cleared, to allow multiple runs for different AS numbers
+ */
+void
+bgpq4_print_counting_filter(FILE *f, struct bgpq_expander *b)
+{
+	switch(b->vendor) {
+	case V_NOKIA_MD:
+		bgpq4_print_nokia_md_counting_filter(f, b);
 		break;
 	default:
 		sx_report(SX_FATAL, "unreachable point\n");


### PR DESCRIPTION
Sample usage:
```
jeroen@host~$ ./bgpq4 -n -c AS13335 -lCloudFlare
/configure filter match-list
delete ip-prefix-list "AS13335"
ip-prefix-list "AS13335" {
    prefix 1.0.0.0/24 { }
    prefix 1.1.1.0/24 { }
    prefix 8.6.112.0/24 { }
    prefix 8.6.144.0/24 { }
    prefix 8.6.145.0/24 { }
    ... etc ...
    prefix 223.27.48.0/20 { }
}
/configure filter md-auto-id { filter-id-range { start 1 end 65535 } }
/configure filter ip-filter "CloudFlare-in" {
default-action accept
entry 13335 { match { src-ip { ip-prefix-list "AS13335" } }
action accept }
}
/configure filter ip-filter "CloudFlare-out" {
default-action accept
entry 13335 { match { dst-ip { ip-prefix-list "AS13335" } }
action accept }
}
```

The generated filters "CloudFlare-in" and "CloudFlare-out" can be assigned as ingress/egress filters to interfaces, to count traffic to/from CloudFlare (based on IRR prefix list matches)

That way, peering operators can gain insight into the amount of traffic (packets/bytes) they are sending/receiving to a given AS, for example to optimize transit peering arrangements