### PR TITLE
Implement firewall address-list output for MikroTik 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,64 @@
+# Derived from https://github.com/github/gitignore/blob/main/Autotools.gitignore
+
+# http://www.gnu.org/software/automake
+
+Makefile.in
+/ar-lib
+/mdate-sh
+/py-compile
+/test-driver
+/ylwrap
+.deps/
+.dirstamp
+
+# http://www.gnu.org/software/autoconf
+
+autom4te.cache
+/autoscan.log
+/autoscan-*.log
+/aclocal.m4
+/compile
+/config.cache
+/config.guess
+/config.h.in
+/config.log
+/config.status
+/config.sub
+/configure
+/configure.scan
+/depcomp
+/install-sh
+/missing
+/stamp-h1
+
+# https://www.gnu.org/software/libtool/
+
+/ltmain.sh
+
+# http://www.gnu.org/software/texinfo
+
+/texinfo.tex
+
+# http://www.gnu.org/software/m4/
+
+m4/libtool.m4
+m4/ltoptions.m4
+m4/ltsugar.m4
+m4/ltversion.m4
+m4/lt~obsolete.m4
+
+# Generated Makefile
+# (meta build system like autotools,
+# can automatically generate from config.status script
+# (which is called by configure script))
+Makefile
+
+# Build artifacts
+build
+configure~
+*.o
+*.lo
+*.a
+*.la
+bgpq4
+libtool

--- a/main.c
+++ b/main.c
@@ -85,9 +85,10 @@ usage(int ecode)
 	printf(" -3        : assume that your device is asn32-safe (default)\n");
 	printf(" -A        : try to aggregate prefix-lists/route-filters\n");
 	printf(" -E        : generate extended access-list (Cisco), "
-	    "route-filter (Juniper)\n"
-	    "             [ip|ipv6]-prefix-list (Nokia) or prefix-set "
-	    "(OpenBGPD)\n");
+		"route-filter (Juniper),\n"
+		"             [ip|ipv6]-prefix-list (Nokia), "
+		"prefix-set (OpenBGPD),\n"
+		"             or firewall address-list (MikroTik)\n");
 	printf(" -f number : generate input as-path access-list\n");
 	printf(" -G number : generate output as-path access-list\n");
 	printf(" -H number : generate origin as-lists (JunOS only)\n");
@@ -579,6 +580,14 @@ main(int argc, char* argv[])
 	    && expander.generation != T_PREFIXLIST) {
 		sx_report(SX_FATAL, "Sorry, aggregation (-A) is not supported with "
 		    "ip-prefix-lists (-E) on Nokia.\n");
+		exit(1);
+	}
+
+	if (aggregate
+	    && (expander.vendor == V_MIKROTIK6 || expander.vendor == V_MIKROTIK7)
+	    && expander.generation == T_EACL) {
+		sx_report(SX_FATAL, "Sorry, aggregation (-A) is not supported with "
+		    "firewall address-list (-E) on MikroTik.\n");
 		exit(1);
 	}
 

--- a/printer.c
+++ b/printer.c
@@ -1896,6 +1896,41 @@ bgpq4_print_mikrotik_prefixlist(FILE *f, struct bgpq_expander *b)
 	}
 }
 
+static void
+bgpq4_print_mikrotik_address(struct sx_radix_node *n, void *ff)
+{
+	char	 prefix[128];
+	FILE	*f = (FILE*)ff;
+
+	if (!f)
+		f = stdout;
+
+	if (n->isGlue)
+		goto checkSon;
+
+	sx_prefix_snprintf_sep(n->prefix, prefix, sizeof(prefix), "/");
+
+	fprintf(f,"/%s firewall address-list add list=\"%s\" address=%s\n",
+			n->prefix->family == AF_INET ? "ip" : "ipv6",
+		    bname, prefix);
+
+checkSon:
+	if (n->son)
+		bgpq4_print_mikrotik_address(n->son, ff);
+}
+
+static void
+bgpq4_print_mikrotik_addresslist(FILE *f, struct bgpq_expander *b)
+{
+	bname = b->name ? b->name : "NN";
+
+	if (!sx_radix_tree_empty(b->tree)) {
+		sx_radix_tree_foreach(b->tree, bgpq4_print_mikrotik_address, f);
+	} else {
+		fprintf(f, "# generated prefix-list %s is empty\n", bname);
+	}
+}
+
 void
 bgpq4_print_prefixlist(FILE *f, struct bgpq_expander *b)
 {
@@ -1968,6 +2003,10 @@ bgpq4_print_eacl(FILE *f, struct bgpq_expander *b)
 		break;
 	case V_NOKIA_SRL:
 		bgpq4_print_nokia_srl_aclipfilter(f, b);
+		break;
+	case V_MIKROTIK6:
+	case V_MIKROTIK7:
+		bgpq4_print_mikrotik_addresslist(f, b);
 		break;
 	default:
 		sx_report(SX_FATAL, "unreachable point\n");


### PR DESCRIPTION
In RouterOS v7 we can setup filters based on firewall address-list.
Thus output prefixes into address-list can be very useful.
Semantics of firewall address-list remain the same in RouterOS v6
as well.

-E option is selected for firewall address-list function.

Ref: https://help.mikrotik.com/docs/display/ROS/Address-lists