### PR TITLE
fixed - mikrotik routerosv7 output

### DIFF
--- a/printer.c
+++ b/printer.c
@@ -1870,7 +1870,7 @@ bgpq4_print_k7prefix(struct sx_radix_node *n, void *ff)
 		    prefix, n->aggregateLow, n->aggregateHi);
 	else
 		fprintf(f,"/routing filter rule add chain=\""
-		    "%s-%s\" rule=\"if (dst=%s) {accept}\"\n",
+		    "%s-%s\" rule=\"if (dst==%s) {accept}\"\n",
 		    bname ? bname : "NN",
 		    n->prefix->family == AF_INET ? "V4" : "V6",
 		    prefix);

--- a/tests/reference/routeros7--4.txt
+++ b/tests/reference/routeros7--4.txt
@@ -1,2 +1,2 @@
-/routing filter rule add chain="NN-V4" rule="if (dst=192.31.196.0/24) {accept}"
-/routing filter rule add chain="NN-V4" rule="if (dst=192.175.48.0/24) {accept}"
+/routing filter rule add chain="NN-V4" rule="if (dst==192.31.196.0/24) {accept}"
+/routing filter rule add chain="NN-V4" rule="if (dst==192.175.48.0/24) {accept}"

--- a/tests/reference/routeros7--6.txt
+++ b/tests/reference/routeros7--6.txt
@@ -1,2 +1,2 @@
-/routing filter rule add chain="NN-V6" rule="if (dst=2001:4:112::/48) {accept}"
-/routing filter rule add chain="NN-V6" rule="if (dst=2620:4f:8000::/48) {accept}"
+/routing filter rule add chain="NN-V6" rule="if (dst==2001:4:112::/48) {accept}"
+/routing filter rule add chain="NN-V6" rule="if (dst==2620:4f:8000::/48) {accept}"


### PR DESCRIPTION
fixed output for mikrotik routerosv7

```
bgpq4 -A -K7l TECHNOLUTIONS AS-TECHNOLUTIONS                                                                          ✔ 
/routing filter rule add chain="TECHNOLUTIONS-V4" rule="if (dst==164.160.24.0/22) {accept}"
/routing filter rule add chain="TECHNOLUTIONS-V4" rule="if (dst==169.255.28.0/22) {accept}"
/routing filter rule add chain="TECHNOLUTIONS-V4"  rule="if (dst in 169.255.28.0/22 && dst-len in 24-24) {accept}"
/routing filter rule add chain="TECHNOLUTIONS-V4" rule="if (dst==196.11.102.0/24) {accept}"
/routing filter rule add chain="TECHNOLUTIONS-V4" rule="if (dst==196.251.232.0/21) {accept}"
/routing filter rule add chain="TECHNOLUTIONS-V4"  rule="if (dst in 196.251.232.0/22 && dst-len in 24-24) {accept}"
/routing filter rule add chain="TECHNOLUTIONS-V4"  rule="if (dst in 196.251.236.0/23 && dst-len in 23-24) {accept}"
/routing filter rule add chain="TECHNOLUTIONS-V4"  rule="if (dst in 196.251.238.0/23 && dst-len in 24-24) {accept}"
```

an additional "=" is added for non-aggregate prefixes