### PR TITLE
Modernize usage of autoconf macros

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -13,7 +13,7 @@
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-AC_INIT([bgpq4], m4_esyscmd([tr -d '\n' < VERSION]), job@sobornost.net)
+AC_INIT([bgpq4], m4_esyscmd([tr -d '\n' < VERSION]), [job@sobornost.net])
 
 AC_CANONICAL_HOST
 AM_INIT_AUTOMAKE([subdir-objects foreign])
@@ -56,9 +56,8 @@ AM_CONDITIONAL([HOST_NETBSD],  [test x$HOST_OS = xnetbsd])
 AM_CONDITIONAL([HOST_SOLARIS], [test x$HOST_OS = xsolaris])
 
 AC_PROG_CC
-AC_PROG_CC_STDC
 AM_PROG_CC_C_O
-AC_PROG_LIBTOOL
+LT_INIT
 AC_PROG_INSTALL
 
 AC_ARG_ENABLE(warnings,


### PR DESCRIPTION
When running `autoreconf --install` (also art of `./bootstrap`), some warnings related to `autoconf` are raised:

```
$ autoreconf --install
aclocal: warning: couldn't open directory 'm4': No such file or directory
libtoolize: putting auxiliary files in '.'.
libtoolize: copying file './ltmain.sh'
libtoolize: putting macros in AC_CONFIG_MACRO_DIRS, 'm4'.
libtoolize: copying file 'm4/libtool.m4'
libtoolize: copying file 'm4/ltoptions.m4'
libtoolize: copying file 'm4/ltsugar.m4'
libtoolize: copying file 'm4/ltversion.m4'
libtoolize: copying file 'm4/lt~obsolete.m4'
configure.ac:59: warning: The macro 'AC_PROG_CC_STDC' is obsolete.
configure.ac:59: You should run autoupdate.
./lib/autoconf/c.m4:1669: AC_PROG_CC_STDC is expanded from...
configure.ac:59: the top level
configure.ac:61: warning: The macro 'AC_PROG_LIBTOOL' is obsolete.
configure.ac:61: You should run autoupdate.
m4/libtool.m4:100: AC_PROG_LIBTOOL is expanded from...
configure.ac:61: the top level
configure.ac:22: installing './compile'
configure.ac:18: installing './config.guess'
configure.ac:18: installing './config.sub'
configure.ac:19: installing './install-sh'
configure.ac:19: installing './missing'
Makefile.am: installing './depcomp'
$ 
```

- `AC_PROG_CC_STDC` is meanwhile done by `AC_PROG_CC`, see: https://www.gnu.org/software/autoconf/manual/autoconf-2.70/html_node/Obsolete-Macros.html
- `AC_PROG_LIBTOOL` can be replaced by `LT_INIT` since libtool v2, dates back to ~ 2008, see also: https://autotools.info/forwardporting/libtool.html
- Finally, `autoconf` loves square brackets ;-)

Running `autoreconf --install` with the suggested changes applied looks finally like this:

```
$ autoreconf --install
aclocal: warning: couldn't open directory 'm4': No such file or directory
libtoolize: putting auxiliary files in '.'.
libtoolize: copying file './ltmain.sh'
libtoolize: putting macros in AC_CONFIG_MACRO_DIRS, 'm4'.
libtoolize: copying file 'm4/libtool.m4'
libtoolize: copying file 'm4/ltoptions.m4'
libtoolize: copying file 'm4/ltsugar.m4'
libtoolize: copying file 'm4/ltversion.m4'
libtoolize: copying file 'm4/lt~obsolete.m4'
configure.ac:22: installing './compile'
configure.ac:18: installing './config.guess'
configure.ac:18: installing './config.sub'
configure.ac:19: installing './install-sh'
configure.ac:19: installing './missing'
Makefile.am: installing './depcomp'
$ 
```

To avoid breaking builds of bgpq4 in maybe non-edge Linux distributions, I've also tested this change with both:

- autoconf 2.72 (Fedora Rawhide, currently 41)
- autoconf 2.69 (RHEL/CentOS 7)

Note that autoconf 2.69 was released in April 2012. When looking to [Repology](https://repology.org/project/autoconf/badges), autoconf >= 2.69 seems to be in all common non-EOL distributions out there.