### PR TITLE
Don't try to login and push to GHCR on forks

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -48,6 +48,7 @@ jobs:
             type=sha
 
       - name: Login to GitHub Container Registry
+        if: github.repository_owner == 'bgp'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -60,5 +61,5 @@ jobs:
           file: .github/images/alpine:3.Dockerfile
           context: .
           platforms: linux/amd64,linux/arm64
-          push: true
+          push: ${{ github.repository_owner == 'bgp' }}
           tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
I'm not sure whether there is a better solution, but for me the CI of the fork fails all the time because it tries to login and to push to the GitHub Container Registry (which fails). Thus I suggest perform these steps only on the main repository.