### PR TITLE
Skip online test if no or empty /etc/resolv.conf

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -36,4 +36,8 @@ maintainer-clean-local:
 check:
 	./bgpq4 -v
 	@echo
-	./bgpq4 -6 AS15562:AS-SNIJDERS | grep 2001:67c:208c::
+	-@if [ -s /etc/resolv.conf ]; then \
+		./bgpq4 -6 AS15562:AS-SNIJDERS | grep 2001:67c:208c::; \
+	else \
+		echo "No or empty /etc/resolv.conf, skipping online test"; \
+	fi


### PR DESCRIPTION
Downstream build systems, e.g. at Linux distributions like Fedora, might be (sealed) offline (chroot) environments.