### PR TITLE
Work around broken Docker image by Rocky Linux (until CentOS 7 is EOL)

### DIFF
--- a/.github/images/centos.Dockerfile
+++ b/.github/images/centos.Dockerfile
@@ -2,8 +2,8 @@ ARG image=centos/centos:latest
 FROM quay.io/$image
 
 # Install dependencies
-RUN yum update -y
-RUN yum install -y autoconf automake gcc libtool make diffutils file gzip
+RUN if command -v yum > /dev/null; then dnf=yum; fi; ${dnf:-dnf} update -y
+RUN if command -v yum > /dev/null; then dnf=yum; fi; ${dnf:-dnf} install -y autoconf automake gcc libtool make diffutils file gzip
 
 # Add source code
 ADD . /src


### PR DESCRIPTION
As pointed out by @job, `docker.io/rockylinux/rockylinux:9` doesn't ship `yum` currently. After talking to Rocky Linux folks, it seems to be accidentially caused when updating the docker image to Rocky Linux 9.4 after switching from imagefactory to kiwi as image builder. Given we still support CentOS 7 (which reaches EOL at 2024-06-30), I added a not so nice workaround for the next two months. After EOL of CentOS 7, I will suggest to switch from `yum` to `dnf`, because `yum` is anyway just a wrapper to `dnf` since RHEL/CentOS/Rocky Linux 8 (and in Fedora even longer).