### PR TITLE
Remove extra space for MikroTik's RouterOS V7 rules

### DIFF
--- a/printer.c
+++ b/printer.c
@@ -1865,7 +1865,7 @@ bgpq4_print_k7prefix(struct sx_radix_node *n, void *ff)
 
 	if (n->isAggregate)
 		fprintf(f,"/routing filter rule add chain=\""
-		    "%s-%s\"  rule=\"if (dst in %s && dst-len in %d-%d) {accept}\"\n",
+		    "%s-%s\" rule=\"if (dst in %s && dst-len in %d-%d) {accept}\"\n",
 		    bname ? bname : "NN",
 		    n->prefix->family == AF_INET ? "V4" : "V6",
 		    prefix, n->aggregateLow, n->aggregateHi);


### PR DESCRIPTION
With aggregated prefixes an extra "space" is printed with `-K7` flags:

<img width="433" alt="image" src="https://github.com/user-attachments/assets/0add43ad-a3ed-4667-b82c-d6ba16c86119">

This PR should fix this ;)