### PR TITLE
Remove extraneous space in Arista prefixlist

### DIFF
--- a/printer.c
+++ b/printer.c
@@ -1165,7 +1165,7 @@ bgpq4_print_eprefix(struct sx_radix_node *n, void *ff)
 
 	sx_prefix_snprintf(n->prefix, prefix, sizeof(prefix));
 
-	snprintf(seqno, sizeof(seqno), " seq %i", seq++);
+	snprintf(seqno, sizeof(seqno), "seq %i", seq++);
 
 	if (n->isAggregate) {
 		if (n->aggregateLow > n->prefix->masklen) {

--- a/tests/reference/eos--4.txt
+++ b/tests/reference/eos--4.txt
@@ -1,4 +1,4 @@
 no ip prefix-list NN
 ip prefix-list NN
-    seq 1 permit 192.31.196.0/24
-    seq 2 permit 192.175.48.0/24
+   seq 1 permit 192.31.196.0/24
+   seq 2 permit 192.175.48.0/24

--- a/tests/reference/eos--6.txt
+++ b/tests/reference/eos--6.txt
@@ -1,4 +1,4 @@
 no ipv6 prefix-list NN
 ipv6 prefix-list NN
-    seq 1 permit 2001:4:112::/48
-    seq 2 permit 2620:4f:8000::/48
+   seq 1 permit 2001:4:112::/48
+   seq 2 permit 2620:4f:8000::/48


### PR DESCRIPTION
When diffing config generated with bgpq4 with config exported from an Arista device, many lines are returned as changed. This is because prefixlist on Arista device use 3 spaces and bgpq4 uses 4 spaces.