### PR TITLE
Fix yaml syntax error

### DIFF
--- a/.github/images/centos.Dockerfile
+++ b/.github/images/centos.Dockerfile
@@ -3,7 +3,7 @@ FROM quay.io/$image
 
 # Install dependencies
 RUN dnf -y update
-RUN dnf -y install autoconf automake gcc libtool make diffutils file gzip
+RUN dnf -y install autoconf automake gcc libtool make diffutils file gzip gawk
 
 # Add source code
 ADD . /src

--- a/.github/images/fedora/fedora:42.Dockerfile
+++ b/.github/images/fedora/fedora:42.Dockerfile
@@ -1,17 +1,1 @@
-ARG image=centos/centos:latest
-FROM quay.io/$image
-
-# Install dependencies
-RUN dnf -y update
-RUN dnf -y install autoconf automake gcc libtool make diffutils file gzip awk
-
-# Add source code
-ADD . /src
-WORKDIR /src
-
-# Run steps
-RUN ./bootstrap
-RUN ./configure
-RUN make
-RUN make check
-RUN make distcheck
+../centos.Dockerfile

--- a/.github/workflows/matrixbuild.yml
+++ b/.github/workflows/matrixbuild.yml
@@ -28,6 +28,6 @@ jobs:
     - uses: actions/checkout@v4
     - name: Work around Docker BuildKit regression
       # https://github.com/moby/buildkit/issues/2119: `DOCKER_BUILDKIT=1 docker build` fails if Dockerfile is a symlink
-      run: [ -L .github/images/${{matrix.dockerenv}}.Dockerfile ] && cp --remove-destination $(readlink -f .github/images/${{matrix.dockerenv}}.Dockerfile) .github/images/${{matrix.dockerenv}}.Dockerfile
+      run: cp --remove-destination $(readlink -f .github/images/${{matrix.dockerenv}}.Dockerfile) .github/images/${{matrix.dockerenv}}.Dockerfile
     - name: Run build on ${{matrix.dockerenv}}
       run: docker build . --file .github/images/${{matrix.dockerenv}}.Dockerfile --build-arg image=${{matrix.dockerenv}}


### PR DESCRIPTION
For me, GitHub reports "Invalid workflow file" and "You have an error in your yaml syntax on line 30" for `matrixbuild.yml` and doesn't run the GitHub action anymore.

Given I'm not sure how to fix this, otherwise, I simply added the (g)awk requirement to the `centos.Dockerfile` as it shouldn't hurt and sooner or later all newer Fedora/Enterprise Linux versions will likely require this.

Alternatively, I'm open for better solutions.