### PR TITLE
Remove duplicate/unreachable if()

### DIFF
--- a/expander.c
+++ b/expander.c
@@ -613,10 +613,6 @@ bgpq_expander_invalidate_asn(struct bgpq_expander *b, const char *q)
 			sx_report(SX_ERROR, "out of range: %s\n", q);
 			return;
 		}
-		if (eptr && *eptr != '\n') {
-			sx_report(SX_ERROR, "no number? %s\n", q);
-			return;
-		}
 
 		find.asn = asn;
 		if ((res = RB_FIND(asn_tree, &b->asnlist, &find)) == NULL) {


### PR DESCRIPTION
Situation:

```
if (*eptr != '\n') { … }
if (errno == ERANGE && asn == ULONG_MAX) { … }
if (asn == 0 || asn >= 4294967295) { … }
if (eptr && *eptr != '\n') { … }
```

From my understanding the last `if()` is duplicate/redundant/unreachable, because whenever the last `if()` evaluates to true, the first `if()` already evaluated to true before.

In general this was spotted by GitHub CodeQL in my fork on GitHub, but as as "redundant null check due to previous dereference" (because `strtoul()` never sets `*eptr` to `NULL`).

The current code was introduced with commit b481111cf6f3593e9cb5e22cf35599b79c78def4; the first `if()` was previously:

```
if (q[0] == '\0' || *eptr != '\0') { … }
```

I'm still not really sure why the previous `*eptr` check was changed from `\0` to `\n` in the commit mentioned above…please cross-check before accepting this pull request.