### PR TITLE
expander.c: logic fix in bgpq_expander_invalidate_asn()

### DIFF
--- a/expander.c
+++ b/expander.c
@@ -619,7 +619,7 @@ bgpq_expander_invalidate_asn(struct bgpq_expander *b, const char *q)
 		}
 
 		find.asn = asn;
-		if ((res = RB_FIND(asn_tree, &b->asnlist, &find)) == NULL) {
+		if ((res = RB_FIND(asn_tree, &b->asnlist, &find)) != NULL) {
 			RB_REMOVE(asn_tree, &b->asnlist, res);
 			free(res);
 		}


### PR DESCRIPTION
In 6c8c6cfec1c4ae5035c7b85f14f74ac27fedf9e3 the semantics of this function changed. Previously, it returned early when it couldn't find the ASN, otherwise removed it. After that commit, it would only try to remove non-existing entries.

@ytti expected `bgpq4 -wG 42 AS-DSS-ALL` to exclude AS400805 from the output as it does not contain any prefixes.